### PR TITLE
Fix: return tool-level isError instead of JSON-RPC -32602 on tool failures

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,9 +8,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   CallToolRequestSchema,
-  ErrorCode,
   ListToolsRequestSchema,
-  McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import { CippService } from '../services/cipp.service.js';
 import { Logger } from '../utils/logger.js';
@@ -121,13 +119,11 @@ Tool categories:
         };
       } catch (error) {
         this.logger.error(`Failed to call tool ${request.params.name}:`, error);
-        if (error instanceof McpError) {
-          throw error;
-        }
-        throw new McpError(
-          ErrorCode.InternalError,
-          `Failed to call tool: ${error instanceof Error ? error.message : 'Unknown error'}`
-        );
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text', text: message }],
+          isError: true,
+        };
       }
     });
 
@@ -252,11 +248,12 @@ Tool categories:
             );
             return { content: result.content, isError: result.isError };
           } catch (error) {
-            if (error instanceof McpError) throw error;
-            throw new McpError(
-              ErrorCode.InternalError,
-              `Failed to call tool: ${error instanceof Error ? error.message : 'Unknown error'}`
-            );
+            this.logger.error(`Failed to call tool ${request.params.name}:`, error);
+            const message = error instanceof Error ? error.message : 'Unknown error';
+            return {
+              content: [{ type: 'text', text: message }],
+              isError: true,
+            };
           }
         });
 


### PR DESCRIPTION
Fixes #3.

## Problem

The CallToolRequest handler previously re-threw `McpError` instances and wrapped other errors as `McpError(InternalError)`. Both paths surface as JSON-RPC errors (`-32602` / `-32603`), which clients interpret as protocol-level failures ("the request was malformed") rather than tool execution failures.

Concretely: calling any tool without `CIPP_BASE_URL` configured returned:
```json
{"error": {"code": -32602, "message": "CIPP_BASE_URL is not configured..."}}
```

LLM clients see this as a malformed request and may retry or surface a confusing error.

## Fix

Both `CallToolRequest` handlers (stdio + HTTP) now catch all errors and return:
```json
{"content": [{"type": "text", "text": "<error message>"}], "isError": true}
```

This brings cipp-mcp in line with halopsa-mcp / datto-rmm-mcp behavior, and satisfies the [`mcp-eval-baseline`](https://github.com/wyre-technology/mcp-eval-baseline) `missing_credentials` assertion.

## Verification

```bash
$ npm run build
$ (initialize + notifications/initialized + tools/call cipp_list_tenants) | node dist/entry.js
{..."isError":true,...}  # was: {"error":{"code":-32602,...}}
```

Also passes the eval suite added in #2.