### PR TITLE
feat(registry): publish to MCP Registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
       issues: write
       pull-requests: write
       packages: write
+    outputs:
+      version: ${{ steps.release-version.outputs.version }}
+      released: ${{ steps.release-version.outputs.released }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -74,9 +77,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get released version
+        id: release-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if gh release view "v$VERSION" --repo ${{ github.repository }} &>/dev/null; then
+            echo "released=true" >> $GITHUB_OUTPUT
+          else
+            echo "released=false" >> $GITHUB_OUTPUT
+          fi
+
   docker:
     name: Build and Push Docker Image
-    needs: test
+    needs: [release]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
@@ -95,11 +111,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get version from package.json
-        id: pkg
+      - name: Resolve release version
+        id: version
+        env:
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
         run: |
-          VERSION=$(node -e 'process.stdout.write(require("./package.json").version)')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if [ -z "$RELEASE_VERSION" ]; then
+            echo "ERROR: needs.release.outputs.version is empty" >&2
+            exit 1
+          fi
+          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Docker metadata
         id: meta
@@ -108,7 +129,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ steps.pkg.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.version }}
             type=sha,prefix=sha-
 
       - name: Build and push
@@ -119,11 +140,47 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ steps.pkg.outputs.version }}
+            VERSION=${{ steps.version.outputs.version }}
             COMMIT_SHA=${{ github.sha }}
             BUILD_DATE=${{ github.event.repository.updated_at }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  mcp-registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    needs: [release, docker]
+    if: needs.release.outputs.released == 'true'
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      VERSION: ${{ needs.release.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+      - name: Stamp version into server.json
+        run: |
+          jq --arg v "$VERSION" \
+            '.version = $v | .packages[0].identifier = "ghcr.io/wyre-technology/cipp-mcp:v" + $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish
+      - name: Verify registry listing
+        run: |
+          sleep 5
+          curl -sf "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.wyre-technology/cipp-mcp" \
+            | jq '.servers[]?.server | {name, version}'
 
   security:
     name: Security Scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,3 +63,4 @@ LABEL org.opencontainers.image.documentation="https://github.com/wyre-technology
 LABEL org.opencontainers.image.url="https://github.com/wyre-technology/cipp-mcp/pkgs/container/cipp-mcp"
 LABEL org.opencontainers.image.vendor="Wyre Technology"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL io.modelcontextprotocol.server.name="io.github.wyre-technology/cipp-mcp"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.wyre-technology/cipp-mcp",
+  "title": "CIPP",
+  "description": "MCP server for CIPP — M365 multi-tenant management for MSPs (users, tenants, policies).",
+  "repository": {
+    "url": "https://github.com/wyre-technology/cipp-mcp",
+    "source": "github"
+  },
+  "version": "0.0.0",
+  "websiteUrl": "https://github.com/wyre-technology/cipp-mcp",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/wyre-technology/cipp-mcp:0.0.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "CIPP_API_URL",
+          "description": "Base URL of your CIPP API instance (e.g. https://cipp-api.example.com)",
+          "isRequired": true,
+          "format": "string"
+        },
+        {
+          "name": "CIPP_CLIENT_ID",
+          "description": "Entra ID application (client) ID used to authenticate to CIPP",
+          "isRequired": true,
+          "format": "string"
+        },
+        {
+          "name": "CIPP_CLIENT_SECRET",
+          "description": "Entra ID client secret for the CIPP application",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "CIPP_TENANT_ID",
+          "description": "Entra ID tenant ID hosting the CIPP application registration",
+          "isRequired": false,
+          "format": "string"
+        },
+        {
+          "name": "MCP_TRANSPORT",
+          "description": "Transport mode for the server. Set to 'stdio' for local CLI use; the image defaults to 'http' for gateway hosting.",
+          "isRequired": false,
+          "default": "stdio",
+          "format": "string"
+        },
+        {
+          "name": "AUTH_MODE",
+          "description": "Credential source: 'env' reads vars locally, 'gateway' expects header injection from the WYRE MCP Gateway.",
+          "isRequired": false,
+          "default": "env",
+          "format": "string"
+        },
+        {
+          "name": "LOG_LEVEL",
+          "description": "Log verbosity: debug, info, warn, error",
+          "isRequired": false,
+          "default": "info",
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Apply the WYRE MCP Registry publishing pattern (matches autotask-mcp #85/#86 and 12 other fleet repos).

## Summary
- Add `io.modelcontextprotocol.server.name` LABEL to Dockerfile final stage
- Add `server.json` (OCI/stdio, name `io.github.wyre-technology/cipp-mcp`, CIPP env vars)
- Wire `release` job outputs (version, released) and add `mcp-registry` job that stamps version, validates, OIDC-authenticates, publishes, and verifies listing
- Switch `docker` job to `needs: [release]` and read version from release outputs (avoids package.json read race; branch protection blocks @semantic-release/git push anyway)

## Deviations from template
- Repo had no prior `server.json` — created fresh from autotask template
- `deploy` job (Azure Container Apps) left alone per scope; still `needs: docker`

## Test plan
- [ ] Merge to main triggers semantic-release, docker build, and mcp-registry publish
- [ ] Verify listing at registry.modelcontextprotocol.io after release