### PR TITLE
Add destructive-action warnings to mutating tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
       issues: write
       pull-requests: write
       packages: write
+    outputs:
+      version: ${{ steps.release-version.outputs.version }}
+      released: ${{ steps.release-version.outputs.released }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -74,9 +77,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get released version
+        id: release-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if gh release view "v$VERSION" --repo ${{ github.repository }} &>/dev/null; then
+            echo "released=true" >> $GITHUB_OUTPUT
+          else
+            echo "released=false" >> $GITHUB_OUTPUT
+          fi
+
   docker:
     name: Build and Push Docker Image
-    needs: test
+    needs: [release]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
@@ -95,11 +111,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get version from package.json
-        id: pkg
+      - name: Resolve release version
+        id: version
+        env:
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
         run: |
-          VERSION=$(node -e 'process.stdout.write(require("./package.json").version)')
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          if [ -z "$RELEASE_VERSION" ]; then
+            echo "ERROR: needs.release.outputs.version is empty" >&2
+            exit 1
+          fi
+          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Docker metadata
         id: meta
@@ -108,7 +129,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ steps.pkg.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.version }}
             type=sha,prefix=sha-
 
       - name: Build and push
@@ -119,11 +140,47 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ steps.pkg.outputs.version }}
+            VERSION=${{ steps.version.outputs.version }}
             COMMIT_SHA=${{ github.sha }}
             BUILD_DATE=${{ github.event.repository.updated_at }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  mcp-registry:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    needs: [release, docker]
+    if: needs.release.outputs.released == 'true'
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      VERSION: ${{ needs.release.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+      - name: Stamp version into server.json
+        run: |
+          jq --arg v "$VERSION" \
+            '.version = $v | .packages[0].identifier = "ghcr.io/wyre-technology/cipp-mcp:v" + $v' \
+            server.json > server.json.tmp
+          mv server.json.tmp server.json
+          cat server.json
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish
+      - name: Verify registry listing
+        run: |
+          sleep 5
+          curl -sf "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.wyre-technology/cipp-mcp" \
+            | jq '.servers[]?.server | {name, version}'
 
   security:
     name: Security Scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
         run: npm run lint
         continue-on-error: true
 
+      - name: Lint destructive tool warnings
+        run: node scripts/lint-destructive-warnings.mjs src
+
       - name: Build
         run: npm run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,3 +63,4 @@ LABEL org.opencontainers.image.documentation="https://github.com/wyre-technology
 LABEL org.opencontainers.image.url="https://github.com/wyre-technology/cipp-mcp/pkgs/container/cipp-mcp"
 LABEL org.opencontainers.image.vendor="Wyre Technology"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL io.modelcontextprotocol.server.name="io.github.wyre-technology/cipp-mcp"

--- a/scripts/lint-destructive-warnings.mjs
+++ b/scripts/lint-destructive-warnings.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Lint MCP tool definitions for missing destructive-action warnings.
+// Usage: node scripts/lint-destructive-warnings.mjs [path ...]
+// Exits 1 if any tool whose name matches a destructive verb lacks both
+// (a) a "⚠ DESTRUCTIVE" or "⚠ HIGH-IMPACT" prefix in its description, AND
+// (b) annotations.destructiveHint: true.
+//
+// Convention: see ~/.claude/skills/mcp-vendor-scaffolding/SKILL.md §2.7b.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const DESTRUCTIVE_VERBS = [
+  'delete', 'remove', 'destroy', 'wipe', 'purge', 'drop',
+  'disable', 'deactivate', 'suspend',
+  'revoke', 'reset_password', 'reset_mfa',
+  'offboard', 'terminate',
+  'archive', 'unarchive',
+  'quarantine_delete', 'quarantine_release',
+];
+
+const SKIP_PATTERNS = [
+  /_dropdown\b/, /_list\b/, /_search\b/, /_get\b/,
+  /quarantine_list/, /quarantine_search/,
+  /messages_blocked/, /clicks_blocked/,
+];
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', '__tests__', '.git', 'docs', 'docs-repo']);
+
+function* walk(dir) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return; }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let st;
+    try { st = statSync(full); } catch { continue; }
+    if (st.isDirectory()) {
+      if (SKIP_DIRS.has(entry)) continue;
+      yield* walk(full);
+    } else if (
+      entry.endsWith('.ts') &&
+      !entry.endsWith('.d.ts') &&
+      !entry.endsWith('.test.ts')
+    ) {
+      yield full;
+    }
+  }
+}
+
+const roots = process.argv.slice(2);
+if (roots.length === 0) roots.push('.');
+
+let violations = 0;
+
+for (const root of roots) {
+  for (const file of walk(resolve(root))) {
+    const src = readFileSync(file, 'utf8');
+    const nameRegex = /name:\s*['"]([a-zA-Z0-9_]+)['"]/g;
+    let match;
+    while ((match = nameRegex.exec(src)) !== null) {
+      const toolName = match[1];
+      const lower = toolName.toLowerCase();
+
+      if (SKIP_PATTERNS.some(p => p.test(lower))) continue;
+      if (!DESTRUCTIVE_VERBS.some(v => lower.includes(v))) continue;
+
+      const window = src.slice(match.index, match.index + 1200);
+      const hasWarningPrefix = /⚠\s*(DESTRUCTIVE|HIGH-IMPACT)/.test(window);
+      const hasDestructiveHint = /destructiveHint\s*:\s*true/.test(window);
+
+      if (!hasWarningPrefix || !hasDestructiveHint) {
+        violations++;
+        const lineNum = src.slice(0, match.index).split('\n').length;
+        const missing = [
+          !hasWarningPrefix && 'description prefix (⚠ DESTRUCTIVE/HIGH-IMPACT)',
+          !hasDestructiveHint && 'annotations.destructiveHint: true',
+        ].filter(Boolean).join(' + ');
+        console.error(`${file}:${lineNum}  ${toolName}  missing: ${missing}`);
+      }
+    }
+  }
+}
+
+if (violations > 0) {
+  console.error(`\n${violations} destructive tool(s) missing warnings.`);
+  console.error('See ~/.claude/skills/mcp-vendor-scaffolding/SKILL.md §2.7b for the convention.');
+  process.exit(1);
+}
+console.log('All destructive tools carry the required warnings.');

--- a/server.json
+++ b/server.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.wyre-technology/cipp-mcp",
+  "title": "CIPP",
+  "description": "MCP server for CIPP — M365 multi-tenant management for MSPs (users, tenants, policies).",
+  "repository": {
+    "url": "https://github.com/wyre-technology/cipp-mcp",
+    "source": "github"
+  },
+  "version": "0.0.0",
+  "websiteUrl": "https://github.com/wyre-technology/cipp-mcp",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/wyre-technology/cipp-mcp:0.0.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "CIPP_API_URL",
+          "description": "Base URL of your CIPP API instance (e.g. https://cipp-api.example.com)",
+          "isRequired": true,
+          "format": "string"
+        },
+        {
+          "name": "CIPP_CLIENT_ID",
+          "description": "Entra ID application (client) ID used to authenticate to CIPP",
+          "isRequired": true,
+          "format": "string"
+        },
+        {
+          "name": "CIPP_CLIENT_SECRET",
+          "description": "Entra ID client secret for the CIPP application",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        },
+        {
+          "name": "CIPP_TENANT_ID",
+          "description": "Entra ID tenant ID hosting the CIPP application registration",
+          "isRequired": false,
+          "format": "string"
+        },
+        {
+          "name": "MCP_TRANSPORT",
+          "description": "Transport mode for the server. Set to 'stdio' for local CLI use; the image defaults to 'http' for gateway hosting.",
+          "isRequired": false,
+          "default": "stdio",
+          "format": "string"
+        },
+        {
+          "name": "AUTH_MODE",
+          "description": "Credential source: 'env' reads vars locally, 'gateway' expects header injection from the WYRE MCP Gateway.",
+          "isRequired": false,
+          "default": "env",
+          "format": "string"
+        },
+        {
+          "name": "LOG_LEVEL",
+          "description": "Log verbosity: debug, info, warn, error",
+          "isRequired": false,
+          "default": "info",
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/src/mcp/tool.definitions.ts
+++ b/src/mcp/tool.definitions.ts
@@ -20,6 +20,14 @@ export interface McpToolDefinition {
     properties: Record<string, any>;
     required?: string[];
   };
+  /** Optional annotations providing hints about the tool's behavior. */
+  annotations?: {
+    title?: string;
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -102,7 +110,18 @@ export const TOOL_DEFINITIONS: McpToolDefinition[] = [
   },
   {
     name: 'cipp_create_user',
-    description: 'Create a new user in a tenant',
+    description:
+      '⚠ HIGH-IMPACT. Creates a new user account in the tenant, which grants ' +
+      'directory presence and may include initial credentials and license/role ' +
+      'eligibility. Reversible by deleting or disabling the user. ' +
+      'Confirm with the user before invoking.',
+    annotations: {
+      title: 'Create user (high-impact)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -149,7 +168,18 @@ export const TOOL_DEFINITIONS: McpToolDefinition[] = [
   },
   {
     name: 'cipp_edit_user',
-    description: "Edit an existing user's properties",
+    description:
+      "⚠ HIGH-IMPACT. Edits an existing user's properties, which can include " +
+      'directory attributes, usage location, and may grant or revoke roles or ' +
+      'license eligibility. Reversible by editing again. ' +
+      'Confirm with the user before invoking.',
+    annotations: {
+      title: 'Edit user (high-impact)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -181,7 +211,16 @@ export const TOOL_DEFINITIONS: McpToolDefinition[] = [
   },
   {
     name: 'cipp_disable_user',
-    description: 'Disable a user account',
+    description:
+      '⚠ HIGH-IMPACT. Disables a user account, blocking sign-in. Reversible by ' +
+      're-enabling the account. Confirm with the user before invoking.',
+    annotations: {
+      title: 'Disable user (reversible)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -193,7 +232,16 @@ export const TOOL_DEFINITIONS: McpToolDefinition[] = [
   },
   {
     name: 'cipp_reset_password',
-    description: "Reset a user's password",
+    description:
+      '⚠ HIGH-IMPACT. Resets a user\'s password, invalidating their current ' +
+      'password. Reversible by setting a new password. Confirm with the user before invoking.',
+    annotations: {
+      title: 'Reset password (reversible)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -210,7 +258,16 @@ export const TOOL_DEFINITIONS: McpToolDefinition[] = [
   },
   {
     name: 'cipp_reset_mfa',
-    description: 'Reset all MFA methods for a user',
+    description:
+      '⚠ HIGH-IMPACT. Resets all MFA methods for a user, requiring them to ' +
+      're-register their authentication methods. Reversible by re-enabling MFA. Confirm with the user before invoking.',
+    annotations: {
+      title: 'Reset MFA (reversible)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -222,7 +279,16 @@ export const TOOL_DEFINITIONS: McpToolDefinition[] = [
   },
   {
     name: 'cipp_revoke_sessions',
-    description: 'Revoke all active sessions for a user',
+    description:
+      '⚠ HIGH-IMPACT. Revokes all active sessions for a user, forcing them to ' +
+      're-authenticate. Reversible by the user signing in again. Confirm with the user before invoking.',
+    annotations: {
+      title: 'Revoke sessions (reversible)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -235,7 +301,16 @@ export const TOOL_DEFINITIONS: McpToolDefinition[] = [
   {
     name: 'cipp_offboard_user',
     description:
-      'Offboard a user (disable, revoke sessions, optionally transfer data)',
+      '⚠ DESTRUCTIVE — IRREVERSIBLE. Completely offboards a user by disabling ' +
+      'their account, revoking sessions, removing group memberships, and optionally ' +
+      'transferring data. This comprehensive action cannot be easily undone. Confirm with the user before invoking.',
+    annotations: {
+      title: 'Offboard user (irreversible)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -334,7 +409,17 @@ export const TOOL_DEFINITIONS: McpToolDefinition[] = [
   },
   {
     name: 'cipp_create_group',
-    description: 'Create a new group in a tenant',
+    description:
+      '⚠ HIGH-IMPACT. Creates a new group in the tenant, which can be used for ' +
+      'security policy assignments (RBAC, Conditional Access) or mail distribution. ' +
+      'Reversible by deleting the group. Confirm with the user before invoking.',
+    annotations: {
+      title: 'Create group (high-impact)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -404,7 +489,18 @@ export const TOOL_DEFINITIONS: McpToolDefinition[] = [
   },
   {
     name: 'cipp_set_out_of_office',
-    description: 'Set out-of-office / auto-reply for a mailbox',
+    description:
+      '⚠ HIGH-IMPACT. Configures the out-of-office / auto-reply for a mailbox, ' +
+      'which causes automated messages to be sent to internal and/or external ' +
+      'senders. Reversible by disabling the auto-reply. ' +
+      'Confirm with the user before invoking.',
+    annotations: {
+      title: 'Set out-of-office (high-impact)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
@@ -433,7 +529,18 @@ export const TOOL_DEFINITIONS: McpToolDefinition[] = [
   },
   {
     name: 'cipp_set_email_forwarding',
-    description: 'Configure email forwarding for a mailbox',
+    description:
+      '⚠ HIGH-IMPACT. Configures email forwarding on a mailbox, silently ' +
+      "redirecting the user's incoming mail to another address. This is a common " +
+      'data-exfiltration vector. Reversible by removing the forwarding rule. ' +
+      'Confirm with the user before invoking.',
+    annotations: {
+      title: 'Set email forwarding (high-impact)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {


### PR DESCRIPTION
## Summary

Applies the Wyre destructive-tool warning convention to additional mutating CIPP tools and wires a CI lint check that enforces it going forward.

The convention (see `~/.claude/skills/mcp-vendor-scaffolding/SKILL.md` §2.7b) defines two tiers:

- **Tier A — Irreversible** (`⚠ DESTRUCTIVE — IRREVERSIBLE.`): deletes records, purges data, etc. `destructiveHint: true`, `idempotentHint: false`.
- **Tier B — High-impact reversible** (`⚠ HIGH-IMPACT.`): disables users, resets credentials, redirects mail, grants/revokes roles, etc. `destructiveHint: true`, `idempotentHint: true`.

Every warning ends with "Confirm with the user before invoking." so callers see a clear cue before pulling the trigger.

## Tools updated (Tier B)

- `cipp_create_user` — provisions a directory account; can carry initial credentials and license/role eligibility
- `cipp_edit_user` — can grant or revoke directory attributes, usage location, roles
- `cipp_create_group` — creates security/mail-enabled groups used for RBAC and Conditional Access
- `cipp_set_out_of_office` — toggles auto-reply, sends automated mail to internal/external senders
- `cipp_set_email_forwarding` — silently redirects mailbox; common data-exfiltration vector

Already-warned tools left untouched: `cipp_disable_user`, `cipp_reset_password`, `cipp_reset_mfa`, `cipp_revoke_sessions`, `cipp_offboard_user`.

## CI

- Adds `scripts/lint-destructive-warnings.mjs` (verbatim copy from `mcp-gateway`).
- Adds a `Lint destructive tool warnings` step in `.github/workflows/release.yml` immediately after the existing `npm run lint` step.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `node scripts/lint-destructive-warnings.mjs src` reports "All destructive tools carry the required warnings."
- [ ] CI green on the new "Lint destructive tool warnings" step