### PR TITLE
fix(lint): add minimal .eslintrc.json (unblocks Release pipeline)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module"
+  },
+  "rules": {
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-explicit-any": "off"
+  }
+}


### PR DESCRIPTION
## Summary
Repo had a \`lint\` script (\`eslint src --ext .ts\`) but no \`.eslintrc.*\` file, so ESLint exited 2 in CI with \"couldn't find a configuration file\". Adds the same baseline config used by halopsa-mcp and liongard-mcp:

- \`eslint:recommended\` + \`plugin:@typescript-eslint/recommended\`
- \`@typescript-eslint/no-unused-vars\` with underscore-ignore
- \`@typescript-eslint/no-explicit-any\` **disabled** — the repo has 11 existing \`any\` usages (tool definitions, config types, logger). Tightening those is **out of scope** for this unblock.

## Why now
Coordinated CI failure across 3 MCP repos (cipp/halopsa/liongard) at 2026-05-13 20:03-04Z after each repo's id-token-grant fix triggered first Release run on this surface. Tracked separately:
- halopsa-mcp#20 — fix actual lint errors (config existed)
- liongard-mcp#18 — fix one unused import (config existed)

## Follow-up (not this PR)
Enable \`@typescript-eslint/no-explicit-any\` and clean the 11 call sites once Conduit ships. Out of scope per release-push posture.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run build\` clean
- [x] \`npm test\` — smoke passes
- [ ] CI green