### PR TITLE
fix(ci): align GHCR tag prefix to fleet canonical + expose docker digest output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
 
@@ -111,7 +113,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=v${{ steps.version.outputs.version }}
             type=sha,prefix=sha-
 
       - name: Build and push


### PR DESCRIPTION
## Summary

Two failures on cipp-mcp Release run [25833828546](https://github.com/wyre-technology/cipp-mcp/actions/runs/25833828546) (2026-05-14T00:12Z) root-caused and fixed in a single 3-line workflow diff.

Handoff: murph triaged the failures last night + handed off to forge for fresh-cycle pickup. Diagnostic captured in forge MEMORY.md.

## Failure 1 — Publish to MCP Registry

**Error:**
```
publish failed: server returned status 400: ... OCI image
'ghcr.io/wyre-technology/cipp-mcp:v1.2.2' does not exist in the registry
```

**Root cause:** tag-prefix mismatch.

The docker metadata-action tagged GHCR images with **bare semver** (`1.2.2`):
```yaml
type=raw,value=${{ steps.version.outputs.version }}
```

But the mcp-registry publish step stamps `server.json` with **`v`-prefix** (`v1.2.2`):
```yaml
'.packages[0].identifier = "ghcr.io/wyre-technology/cipp-mcp:v" + $v'
```

MCP Registry tries to verify `v1.2.2` exists → 404 (GHCR only has `1.2.2`).

**Fleet canonical** (halopsa-mcp) tags WITH `v` prefix — confirmed by inspecting halopsa GHCR versions: `["v1.5.2","sha-f10bd2b","latest"]`. cipp had drifted; this PR aligns it.

**Fix:** change docker metadata-action tag from `value=${VERSION}` to `value=v${VERSION}`. Single character. Fleet-conforming.

## Failure 2 — Deploy to Azure Container Apps

**Error:**
```
Input 'digest' is empty. Pass the docker/build-push-action digest output
(steps.<id>.outputs.digest) — refusing to deploy by mutable :latest tag.
```

**Root cause:** missing job-level output declaration.

The docker job has `id: push` on the build-push-action step:
```yaml
- name: Build and push
  id: push
  uses: docker/build-push-action@...
```

But the job spec doesn't expose the digest at the job level. The deploy job consumes:
```yaml
digest: ${{ needs.docker.outputs.digest }}
```

Which resolves to empty string. The immutable-deploy safety gate (refusing mutable `:latest` tag deploys) correctly refuses to proceed.

**Fix:** add `outputs: { digest: ${{ steps.push.outputs.digest }} }` to the docker job spec.

## Diff

```diff
   docker:
     name: Build and Push Docker Image
     needs: [release]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
       ...
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=v${{ steps.version.outputs.version }}
             type=sha,prefix=sha-
```

3-line change in `.github/workflows/release.yml`.

## Skill cross-reference

`~/.claude/skills/mcp-registry-publish-gating/` covers the "OCI image does not exist" family across the fleet (autotask/domotz/syncro/datto-rmm/halopsa). cipp's specific shape (tag-prefix mismatch within an already-correctly-ordered workflow) is a sub-variant of that family — the ordering gate (`needs: [release, docker]`) was already correct; the gap was tag-naming convention.

Worth a small addition to that skill's diagnosis section: "if needs:docker is in place but Publish still fails with OCI-image-does-not-exist, check the version-tag prefix consistency between docker metadata-action tagging and server.json stamping."

## Walter 5-area pre-emption

**Area 1 (privilege):** zero — no permission scope changes, no new secret references.
**Area 2 (pinning):** action-version pins (`@c299e40c...` for metadata-action, etc.) unchanged. The `v`-prefix change ALIGNS cipp with halopsa fleet canonical, so future scaffolds inherit the correct shape.
**Area 3 (input validation):** N/A — workflow expression changes only.
**Area 4 (verification):** the safety gate (immutable-deploy refusal on empty digest) was working as designed — caught the missing-output gap. This PR feeds it the digest it expects rather than disabling the gate.
**Area 5 (blast radius):** improves the chain: next Release run on main → Docker tags with `v1.2.3` → Registry publish succeeds → Deploy receives valid digest → ACA gets immutable SHA-pinned image. Failure mode if PR ships wrong: same as today (broken Publish + broken Deploy) — no worse blast radius.

## Test plan

- [ ] CI on this PR: Test workflow passes (no code changes, just workflow file)
- [ ] Boss diff under low-risk autonomy
- [ ] Autonomous merge under expansion
- [ ] Next push-to-main triggers Release → verify Publish to MCP Registry succeeds (no more OCI-image-not-found)
- [ ] Same Release → verify Deploy to ACA receives non-empty digest + proceeds past safety gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)