### PR TITLE
fix: correct cipp_list_domain_health to use the real CIPP API contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Gateway-mode headers for OAuth: `x-tenant-id`, `x-client-id`,
   `x-client-secret`, `x-token-scope`, `x-token-url`.
 
+### Fixed
+- `cipp_list_domain_health` returned no data — it called CIPP's
+  `ListDomainHealth` function with only `tenantFilter`. That function is a
+  per-domain DNS helper requiring `Action` + `Domain` query parameters and
+  ignores `tenantFilter`; called without them it returns HTTP 200 with an
+  empty body, which crashed the client with "Unexpected end of JSON input".
+  The tool now enumerates the tenant's domains via `ListDomains`, then runs
+  the SPF / DMARC / DKIM checks per domain.
+- The HTTP client no longer throws a JSON-parse error on an empty `2xx`
+  response body; such responses are treated as "no content".
+
 ### Changed
 - `CIPP_API_KEY` remains supported as a static Bearer token for backwards
   compatibility. When both static and OAuth credentials are provided, the

--- a/src/services/cipp.service.ts
+++ b/src/services/cipp.service.ts
@@ -27,6 +27,14 @@ interface CippServiceConfig {
   };
 }
 
+/** Aggregated DNS health for a single domain (SPF / DMARC / DKIM). */
+export interface DomainHealthCheck {
+  domain: string;
+  spf: unknown;
+  dmarc: unknown;
+  dkim: unknown;
+}
+
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
@@ -165,8 +173,15 @@ export class CippService {
       );
     }
 
+    const text = await response.text();
+    if (text.trim() === '') {
+      // Some CIPP endpoints legitimately return HTTP 200 with an empty body.
+      // Treat that as "no content" rather than crashing on a JSON parse error.
+      return undefined as T;
+    }
+
     try {
-      return (await response.json()) as T;
+      return JSON.parse(text) as T;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new McpError(
@@ -581,13 +596,55 @@ export class CippService {
   }
 
   /**
-   * List DNS and domain health check results for a tenant.
-   * Calls the `ListDomainHealth` Azure Function.
+   * List the DNS domains registered in a tenant.
+   * Calls the `ListDomains` Azure Function.
    *
    * @param tenantFilter - Tenant domain or identifier.
    */
-  async listDomainHealth<T = unknown>(tenantFilter: string): Promise<T> {
-    return this.request<T>('GET', 'ListDomainHealth', { tenantFilter });
+  async listDomains<T = unknown>(tenantFilter: string): Promise<T> {
+    return this.request<T>('GET', 'ListDomains', { tenantFilter });
+  }
+
+  /**
+   * Check DNS health (SPF, DMARC, DKIM) for every domain in a tenant.
+   *
+   * The CIPP `ListDomainHealth` Azure Function is a per-domain DNS helper: it
+   * requires `Action` + `Domain` query parameters and ignores `tenantFilter`.
+   * Called with only `tenantFilter` it returns HTTP 200 with an empty body.
+   * This method therefore enumerates the tenant's domains via `ListDomains`
+   * first, then runs the SPF / DMARC / DKIM checks per domain.
+   *
+   * @param tenantFilter - Tenant domain or identifier.
+   * @returns One {@link DomainHealthCheck} per domain in the tenant.
+   */
+  async listDomainHealth(tenantFilter: string): Promise<DomainHealthCheck[]> {
+    const domains = await this.listDomains<Array<{ id?: string }>>(tenantFilter);
+    const domainNames = (Array.isArray(domains) ? domains : [])
+      .map((d) => d?.id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+    return Promise.all(
+      domainNames.map(async (domain) => {
+        const [spf, dmarc, dkim] = await Promise.all([
+          this.checkDomainRecord(domain, 'ReadSpfRecord'),
+          this.checkDomainRecord(domain, 'ReadDmarcPolicy'),
+          this.checkDomainRecord(domain, 'ReadDkimRecord'),
+        ]);
+        return { domain, spf, dmarc, dkim };
+      })
+    );
+  }
+
+  /**
+   * Run a single `ListDomainHealth` DNS check for one domain. Per-check
+   * failures are captured so one bad lookup does not sink the whole tenant.
+   */
+  private async checkDomainRecord(domain: string, action: string): Promise<unknown> {
+    try {
+      return await this.request('GET', 'ListDomainHealth', { Action: action, Domain: domain });
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : String(err) };
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/tests/cipp.service.domain-health.test.ts
+++ b/tests/cipp.service.domain-health.test.ts
@@ -1,0 +1,84 @@
+// Tests for CippService.listDomainHealth.
+//
+// Regression: the CIPP `ListDomainHealth` Azure Function is a per-domain DNS
+// helper that requires `Action` + `Domain` query params and ignores
+// `tenantFilter`. Calling it with only `tenantFilter` returns HTTP 200 with an
+// empty body, which crashed the old implementation with
+// "Unexpected end of JSON input".
+//
+// The correct flow: enumerate the tenant's domains via `ListDomains`, then run
+// SPF / DMARC / DKIM checks against `ListDomainHealth` for each domain.
+
+import { CippService } from '../src/services/cipp.service.js';
+import { Logger } from '../src/utils/logger.js';
+
+const logger = new Logger('error');
+
+function jsonResponse(payload: unknown): Response {
+  const text = JSON.stringify(payload);
+  return {
+    ok: true,
+    status: 200,
+    text: async () => text,
+    json: async () => JSON.parse(text),
+  } as unknown as Response;
+}
+
+function emptyResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => '',
+    json: async () => {
+      throw new SyntaxError('Unexpected end of JSON input');
+    },
+  } as unknown as Response;
+}
+
+describe('CippService.listDomainHealth', () => {
+  let svc: CippService;
+
+  beforeEach(() => {
+    svc = new CippService({ cipp: { baseUrl: 'https://cipp.example', apiKey: 'test-key' } }, logger);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('enumerates tenant domains then checks SPF/DMARC/DKIM for each', async () => {
+    const fetchMock = jest.fn((url: string) => {
+      const u = new URL(url);
+      if (u.pathname.endsWith('/api/ListDomains')) {
+        return Promise.resolve(jsonResponse([{ id: 'contoso.com' }, { id: 'contoso.onmicrosoft.com' }]));
+      }
+      if (u.pathname.endsWith('/api/ListDomainHealth')) {
+        return Promise.resolve(
+          jsonResponse({ action: u.searchParams.get('Action'), domain: u.searchParams.get('Domain') })
+        );
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = (await svc.listDomainHealth('contoso.com')) as unknown as Array<
+      Record<string, unknown>
+    >;
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ domain: 'contoso.com' });
+    expect(result[0].spf).toMatchObject({ action: 'ReadSpfRecord', domain: 'contoso.com' });
+    expect(result[0].dmarc).toMatchObject({ action: 'ReadDmarcPolicy', domain: 'contoso.com' });
+    expect(result[0].dkim).toMatchObject({ action: 'ReadDkimRecord', domain: 'contoso.com' });
+
+    const calls = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(calls.filter((c) => c.includes('/api/ListDomains')).length).toBe(1);
+    // 3 checks (SPF/DMARC/DKIM) x 2 domains
+    expect(calls.filter((c) => c.includes('/api/ListDomainHealth')).length).toBe(6);
+  });
+
+  it('returns an empty list (no crash) when the tenant has no domains', async () => {
+    global.fetch = jest.fn(() => Promise.resolve(emptyResponse())) as unknown as typeof fetch;
+    await expect(svc.listDomainHealth('contoso.com')).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

`cipp_list_domain_health` returned no usable data for any tenant — the fleet audit could not assess SPF/DKIM/DMARC posture anywhere.

**Root cause:** the tool called CIPP's `ListDomainHealth` Azure Function with only `tenantFilter`. That function is a **per-domain DNS helper** — it requires `Action` (e.g. `ReadSpfRecord`) + `Domain` query params and ignores `tenantFilter`. Called without `Action`, the PowerShell function never assigns `$body` and returns **HTTP 200 with an empty body**, which crashed the client with `Unexpected end of JSON input`.

## Fix

- **`listDomainHealth()`** now enumerates the tenant's domains via the `ListDomains` function, then runs SPF / DMARC / DKIM checks per domain against `ListDomainHealth` with the correct `Action` + `Domain` params. Per-check failures are captured so one bad lookup doesn't sink the whole tenant.
- Added **`listDomains()`** service method.
- **Hardened the HTTP client** — an empty `2xx` body is now treated as "no content" instead of throwing a JSON parse error (defense-in-depth).
- The tool's external interface (`tenantFilter` input) is unchanged — no breaking change for MCP clients.

## Testing

- New `tests/cipp.service.domain-health.test.ts` — written test-first; reproduced the exact crash, then fixed.
- `npm test` → 3 passing. `npm run lint` clean. `tsc` build clean.