### PR TITLE
fix: bound cipp_list_domain_health DNS checks with a per-check timeout

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"d9adb0cf-85e7-4442-9552-65b91fa77059","pid":24826,"procStart":"Tue May 19 13:08:36 2026","acquiredAt":1779199211663}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the SPF / DMARC / DKIM checks per domain.
 - The HTTP client no longer throws a JSON-parse error on an empty `2xx`
   response body; such responses are treated as "no content".
+- `cipp_list_domain_health` could time out at the MCP gateway on tenants
+  with several domains: each SPF / DMARC / DKIM check resolves DNS
+  server-side at CIPP and the fan-out of slow lookups exceeded the
+  gateway's tool-call deadline. Each per-domain DNS check now carries a
+  15s abort timeout; a stuck lookup is reported as an `{ error }`
+  placeholder for that record instead of hanging the whole tenant.
 
 ### Changed
 - `CIPP_API_KEY` remains supported as a static Bearer token for backwards

--- a/src/services/cipp.service.ts
+++ b/src/services/cipp.service.ts
@@ -35,6 +35,14 @@ export interface DomainHealthCheck {
   dkim: unknown;
 }
 
+/**
+ * Per-check timeout (ms) for `ListDomainHealth` DNS lookups. Each check
+ * resolves DNS server-side at CIPP and can be slow; bounding each one keeps
+ * a single stuck lookup from hanging the whole tenant response past the
+ * MCP gateway's tool-call deadline.
+ */
+const DOMAIN_HEALTH_CHECK_TIMEOUT_MS = 15_000;
+
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
@@ -102,7 +110,8 @@ export class CippService {
     method: HttpMethod,
     path: string,
     params?: Record<string, unknown>,
-    body?: Record<string, unknown>
+    body?: Record<string, unknown>,
+    timeoutMs?: number
   ): Promise<T> {
     if (!this.baseUrl) {
       throw new McpError(ErrorCode.InvalidParams, 'CIPP_BASE_URL is not configured. Set it in your environment or MCP client config.');
@@ -138,6 +147,12 @@ export class CippService {
 
     if (method !== 'GET' && body !== undefined) {
       requestInit.body = JSON.stringify(body);
+    }
+
+    if (timeoutMs !== undefined) {
+      // Aborts the fetch if the response is not received in time. The abort
+      // surfaces as a network error below, which callers can catch per request.
+      requestInit.signal = AbortSignal.timeout(timeoutMs);
     }
 
     this.logger.debug('CIPP API request', { method, url: url.toString() });
@@ -641,7 +656,13 @@ export class CippService {
    */
   private async checkDomainRecord(domain: string, action: string): Promise<unknown> {
     try {
-      return await this.request('GET', 'ListDomainHealth', { Action: action, Domain: domain });
+      return await this.request(
+        'GET',
+        'ListDomainHealth',
+        { Action: action, Domain: domain },
+        undefined,
+        DOMAIN_HEALTH_CHECK_TIMEOUT_MS
+      );
     } catch (err) {
       return { error: err instanceof Error ? err.message : String(err) };
     }

--- a/tests/cipp.service.domain-health.test.ts
+++ b/tests/cipp.service.domain-health.test.ts
@@ -81,4 +81,50 @@ describe('CippService.listDomainHealth', () => {
     global.fetch = jest.fn(() => Promise.resolve(emptyResponse())) as unknown as typeof fetch;
     await expect(svc.listDomainHealth('contoso.com')).resolves.toEqual([]);
   });
+
+  it('bounds each per-domain DNS check with an abort signal', async () => {
+    const fetchMock = jest.fn((url: string, _init?: RequestInit) => {
+      const u = new URL(url);
+      if (u.pathname.endsWith('/api/ListDomains')) {
+        return Promise.resolve(jsonResponse([{ id: 'contoso.com' }]));
+      }
+      return Promise.resolve(jsonResponse({ ok: true }));
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await svc.listDomainHealth('contoso.com');
+
+    // Every ListDomainHealth call must carry an AbortSignal so a slow DNS
+    // lookup cannot hang the whole tenant response.
+    const healthCalls = fetchMock.mock.calls.filter((c) =>
+      (c[0] as string).includes('/api/ListDomainHealth')
+    );
+    expect(healthCalls).toHaveLength(3);
+    for (const call of healthCalls) {
+      const init = call[1] as RequestInit | undefined;
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it('captures a failed check as an error placeholder without sinking the tenant', async () => {
+    const fetchMock = jest.fn((url: string) => {
+      const u = new URL(url);
+      if (u.pathname.endsWith('/api/ListDomains')) {
+        return Promise.resolve(jsonResponse([{ id: 'contoso.com' }]));
+      }
+      if (u.searchParams.get('Action') === 'ReadDkimRecord') {
+        return Promise.reject(new Error('The operation was aborted due to timeout'));
+      }
+      return Promise.resolve(jsonResponse({ record: u.searchParams.get('Action') }));
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = (await svc.listDomainHealth('contoso.com')) as unknown as Array<
+      Record<string, unknown>
+    >;
+
+    expect(result).toHaveLength(1);
+    expect(result[0].spf).toMatchObject({ record: 'ReadSpfRecord' });
+    expect(result[0].dkim).toMatchObject({ error: expect.stringContaining('aborted') });
+  });
 });


### PR DESCRIPTION
## Problem

Follow-up to #16. That PR fixed `cipp_list_domain_health` crashing with
"Unexpected end of JSON input", but verification against a real
multi-domain tenant (`acuraofchattanooga.com`) surfaced a new failure
mode: the tool **times out at the MCP gateway**.

Each SPF/DMARC/DKIM check is a live DNS resolution performed server-side
at CIPP. Even fully parallelized, a tenant with several domains fans out
to many slow concurrent calls, and the slowest one gates the whole
response past the gateway's tool-call deadline. The old code failed fast
(crash); the #16 code failed slow (timeout).

## Fix

- Add an optional `timeoutMs` parameter to the internal `request()`
  helper, wired through `AbortSignal.timeout`.
- Apply a **15s** bound (`DOMAIN_HEALTH_CHECK_TIMEOUT_MS`) to each
  `ListDomainHealth` check.
- A stuck lookup is caught by the existing per-check handler and reported
  as an `{ error }` placeholder for that record — the rest of the tenant
  result is unaffected.

Paired with a modest increase to the gateway's tool-call timeout
(separate change, gateway repo) for headroom on legitimately large
tenants.

## Tests

- `bounds each per-domain DNS check with an abort signal` — asserts every
  `ListDomainHealth` fetch carries an `AbortSignal`.
- `captures a failed check as an error placeholder without sinking the
  tenant` — one rejecting check yields `{ error }`, siblings still resolve.
- Full suite: 5 passed. Build + lint clean.