### PR TITLE
chore: gitignore .claude/ and drop stray scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"d9adb0cf-85e7-4442-9552-65b91fa77059","pid":24826,"procStart":"Tue May 19 13:08:36 2026","acquiredAt":1779199211663}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 *.log
 coverage/
 .DS_Store
+
+# Claude Code local runtime artifacts
+.claude/


### PR DESCRIPTION
Removes a `.claude/scheduled_tasks.lock` runtime artifact that was committed by accident in #17, and adds `.claude/` to `.gitignore` so Claude Code local runtime files are never versioned again. No code changes.