### PR TITLE
feat: skip .onmicrosoft.com routing domains in cipp_list_domain_health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   placeholder for that record instead of hanging the whole tenant.
 
 ### Changed
+- `cipp_list_domain_health` now skips the tenant's `.onmicrosoft.com`
+  routing domain. That domain carries no real customer mail DNS, so its
+  SPF / DMARC / DKIM checks only ever hung or failed with no actionable
+  result.
 - `CIPP_API_KEY` remains supported as a static Bearer token for backwards
   compatibility. When both static and OAuth credentials are provided, the
   static `apiKey` wins.

--- a/src/services/cipp.service.ts
+++ b/src/services/cipp.service.ts
@@ -636,7 +636,11 @@ export class CippService {
     const domains = await this.listDomains<Array<{ id?: string }>>(tenantFilter);
     const domainNames = (Array.isArray(domains) ? domains : [])
       .map((d) => d?.id)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+      .filter((id): id is string => typeof id === 'string' && id.length > 0)
+      // Skip the tenant's `.onmicrosoft.com` routing domain: it carries no
+      // real customer mail DNS, so SPF/DMARC/DKIM checks against it only
+      // ever hang or fail with no actionable result.
+      .filter((id) => !id.toLowerCase().endsWith('.onmicrosoft.com'));
 
     return Promise.all(
       domainNames.map(async (domain) => {

--- a/tests/cipp.service.domain-health.test.ts
+++ b/tests/cipp.service.domain-health.test.ts
@@ -50,7 +50,7 @@ describe('CippService.listDomainHealth', () => {
     const fetchMock = jest.fn((url: string) => {
       const u = new URL(url);
       if (u.pathname.endsWith('/api/ListDomains')) {
-        return Promise.resolve(jsonResponse([{ id: 'contoso.com' }, { id: 'contoso.onmicrosoft.com' }]));
+        return Promise.resolve(jsonResponse([{ id: 'contoso.com' }, { id: 'contoso.net' }]));
       }
       if (u.pathname.endsWith('/api/ListDomainHealth')) {
         return Promise.resolve(
@@ -80,6 +80,30 @@ describe('CippService.listDomainHealth', () => {
   it('returns an empty list (no crash) when the tenant has no domains', async () => {
     global.fetch = jest.fn(() => Promise.resolve(emptyResponse())) as unknown as typeof fetch;
     await expect(svc.listDomainHealth('contoso.com')).resolves.toEqual([]);
+  });
+
+  it('skips .onmicrosoft.com routing domains', async () => {
+    const fetchMock = jest.fn((url: string) => {
+      const u = new URL(url);
+      if (u.pathname.endsWith('/api/ListDomains')) {
+        return Promise.resolve(
+          jsonResponse([{ id: 'contoso.com' }, { id: 'contoso.onmicrosoft.com' }])
+        );
+      }
+      return Promise.resolve(jsonResponse({ domain: u.searchParams.get('Domain') }));
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = (await svc.listDomainHealth('contoso.com')) as unknown as Array<
+      Record<string, unknown>
+    >;
+
+    // The routing domain carries no real mail DNS, so it is not checked.
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ domain: 'contoso.com' });
+
+    const calls = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(calls.some((c) => c.includes('onmicrosoft.com'))).toBe(false);
   });
 
   it('bounds each per-domain DNS check with an abort signal', async () => {


### PR DESCRIPTION
## Why

Follow-up to #17. Verifying the timeout fix against a real tenant showed
that the `.onmicrosoft.com` routing domain always returns
`{ error: timeout }` for its SPF/DMARC/DKIM checks — it carries no real
customer mail DNS, so those lookups just hang at CIPP until the 15s
per-check timeout fires. Harmless (isolated to that domain) but pure
noise in the result.

## Change

Filter `.onmicrosoft.com` domains out of the enumerated domain list
before fanning out the per-domain DNS checks. Real customer domains are
unaffected.

## Tests

- New: `skips .onmicrosoft.com routing domains` — asserts the routing
  domain produces no result entry and no `ListDomainHealth` fetch.
- Existing multi-domain test updated to use two real domains
  (`contoso.com` + `contoso.net`) so it still exercises the fan-out.
- Full suite: 6 passed. Build + lint clean.