### PR TITLE
feat: CIPP Standards Template tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (optional: `CIPP_TOKEN_SCOPE`, `CIPP_TOKEN_URL`).
 - Gateway-mode headers for OAuth: `x-tenant-id`, `x-client-id`,
   `x-client-secret`, `x-token-scope`, `x-token-url`.
+- Standards Template tooling: `cipp_list_standard_templates`,
+  `cipp_create_standard_template`, and `cipp_delete_standard_template`
+  manage CIPP Standards Templates; `cipp_get_tenant_drift` and
+  `cipp_get_tenant_alignment` report per-tenant standards drift and
+  alignment. This lets a standards baseline be managed as code.
 
 ### Fixed
 - `cipp_list_domain_health` returned no data — it called CIPP's

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -315,6 +315,38 @@ export class CippToolHandler {
           break;
         }
 
+        case 'cipp_list_standard_templates': {
+          result = await this.cippService.listStandardTemplates();
+          break;
+        }
+
+        // `tenantFilter` is optional for these two tools: omit it to report
+        // across all tenants. This diverges intentionally from other Standards
+        // cases that require it.
+        case 'cipp_get_tenant_drift': {
+          const { tenantFilter } = args as { tenantFilter?: string };
+          result = await this.cippService.getTenantDrift(tenantFilter);
+          break;
+        }
+
+        case 'cipp_get_tenant_alignment': {
+          const { tenantFilter } = args as { tenantFilter?: string };
+          result = await this.cippService.getTenantAlignment(tenantFilter);
+          break;
+        }
+
+        case 'cipp_create_standard_template': {
+          const { template } = args as { template: Record<string, unknown> };
+          result = await this.cippService.createStandardTemplate(template);
+          break;
+        }
+
+        case 'cipp_delete_standard_template': {
+          const { templateId } = args as { templateId: string };
+          result = await this.cippService.deleteStandardTemplate(templateId);
+          break;
+        }
+
         case 'cipp_list_bpa': {
           const { tenantFilter } = args as { tenantFilter: string };
           result = await this.cippService.listBPA(tenantFilter);

--- a/src/mcp/tool.definitions.ts
+++ b/src/mcp/tool.definitions.ts
@@ -617,6 +617,113 @@ export const TOOL_DEFINITIONS: McpToolDefinition[] = [
     },
   },
   {
+    name: 'cipp_list_standard_templates',
+    description: 'List the CIPP Standards Templates configured across the partner tenant.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    annotations: {
+      title: 'List standards templates',
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: 'cipp_get_tenant_drift',
+    description:
+      'Report standards drift — settings that deviate from a tenant\'s assigned ' +
+      'Standards Template. Omit tenantFilter to report drift across all tenants.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tenantFilter: {
+          type: 'string',
+          description:
+            'Optional tenant domain or ID. Omit to report drift across all managed tenants.',
+        },
+      },
+    },
+    annotations: {
+      title: 'Get tenant standards drift',
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: 'cipp_get_tenant_alignment',
+    description:
+      "Report each tenant's alignment percentage against its assigned Standards " +
+      'Templates — the key signal for deciding which standards are safe to ' +
+      'promote to Remediate. Omit tenantFilter to report on all tenants.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tenantFilter: {
+          type: 'string',
+          description:
+            'Optional tenant domain or ID. Omit to report alignment across all managed tenants.',
+        },
+      },
+    },
+    annotations: {
+      title: 'Get tenant standards alignment',
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: 'cipp_create_standard_template',
+    description:
+      '⚠ HIGH-IMPACT. Creates or updates a CIPP Standards Template (upsert by ' +
+      'GUID). A template assigned to tenants with any Remediate-action standard ' +
+      'WILL modify those tenants on the next standards run. ' +
+      'Confirm with the user before invoking.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        template: {
+          type: 'object',
+          description:
+            'The full Standards Template JSON object. Must include a "tenantFilter" ' +
+            'assigning it to at least one tenant.',
+        },
+      },
+      required: ['template'],
+    },
+    annotations: {
+      title: 'Create/update standards template (high-impact)',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
+  {
+    name: 'cipp_delete_standard_template',
+    description:
+      '⚠ HIGH-IMPACT. Permanently deletes a CIPP Standards Template by ID. ' +
+      'Tenants assigned to it lose the standards it enforced. ' +
+      'Confirm with the user before invoking.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        templateId: {
+          type: 'string',
+          description: 'The GUID of the Standards Template to delete.',
+        },
+      },
+      required: ['templateId'],
+    },
+    annotations: {
+      title: 'Delete standards template (high-impact)',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+  },
+  {
     name: 'cipp_list_bpa',
     description: 'Get Best Practice Analyser results for a tenant',
     inputSchema: {
@@ -831,6 +938,11 @@ export const TOOL_CATEGORIES: Record<string, string[]> = {
   standards: [
     'cipp_list_standards',
     'cipp_run_standards_check',
+    'cipp_list_standard_templates',
+    'cipp_get_tenant_drift',
+    'cipp_get_tenant_alignment',
+    'cipp_create_standard_template',
+    'cipp_delete_standard_template',
     'cipp_list_bpa',
     'cipp_list_domain_health',
   ],

--- a/src/services/cipp.service.ts
+++ b/src/services/cipp.service.ts
@@ -669,6 +669,18 @@ export class CippService {
   }
 
   /**
+   * Delete a CIPP Standards Template by ID.
+   * Calls the `RemoveStandardTemplate` Azure Function.
+   *
+   * @param templateId - The GUID of the Standards Template to delete.
+   */
+  async deleteStandardTemplate<T = unknown>(templateId: string): Promise<T> {
+    return this.request<T>('POST', 'RemoveStandardTemplate', undefined, {
+      ID: templateId,
+    });
+  }
+
+  /**
    * Retrieve Best Practice Analyser (BPA) results for a tenant.
    * Calls the `ListBPA` Azure Function.
    *

--- a/src/services/cipp.service.ts
+++ b/src/services/cipp.service.ts
@@ -639,6 +639,36 @@ export class CippService {
   }
 
   /**
+   * Create or update a CIPP Standards Template (CIPP upserts by GUID).
+   * Calls the `AddStandardsTemplate` Azure Function.
+   *
+   * The template object is passed through to CIPP unchanged — cipp-mcp
+   * does not model CIPP's template schema, which keeps this tool stable
+   * across CIPP versions. Validation is intentionally light: the object
+   * must exist and carry a `tenantFilter` assigning it to at least one
+   * tenant (CIPP itself rejects templates without one).
+   *
+   * @param template - The full Standards Template JSON object.
+   */
+  async createStandardTemplate<T = unknown>(
+    template: Record<string, unknown>
+  ): Promise<T> {
+    if (template === null || typeof template !== 'object' || Array.isArray(template)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'Standards template must be a JSON object.'
+      );
+    }
+    if (template.tenantFilter === undefined || template.tenantFilter === null) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'Standards template must include a "tenantFilter" assigning it to at least one tenant.'
+      );
+    }
+    return this.request<T>('POST', 'AddStandardsTemplate', undefined, template);
+  }
+
+  /**
    * Retrieve Best Practice Analyser (BPA) results for a tenant.
    * Calls the `ListBPA` Azure Function.
    *

--- a/src/services/cipp.service.ts
+++ b/src/services/cipp.service.ts
@@ -601,6 +601,44 @@ export class CippService {
   }
 
   /**
+   * List the CIPP Standards Templates configured across the partner tenant.
+   * Calls the `listStandardTemplates` Azure Function.
+   */
+  async listStandardTemplates<T = unknown>(): Promise<T> {
+    // CIPP names this function with a lowercase 'l' — do not capitalise.
+    return this.request<T>('GET', 'listStandardTemplates');
+  }
+
+  /**
+   * Report standards drift for a tenant, or for every tenant when no
+   * `tenantFilter` is given. Calls the `ListTenantDrift` Azure Function.
+   *
+   * @param tenantFilter - Optional tenant domain or identifier.
+   */
+  async getTenantDrift<T = unknown>(tenantFilter?: string): Promise<T> {
+    return this.request<T>(
+      'GET',
+      'ListTenantDrift',
+      tenantFilter ? { tenantFilter } : undefined
+    );
+  }
+
+  /**
+   * Report each tenant's alignment percentage against its assigned
+   * Standards Templates, or for every tenant when no `tenantFilter` is
+   * given. Calls the `ListTenantAlignment` Azure Function.
+   *
+   * @param tenantFilter - Optional tenant domain or identifier.
+   */
+  async getTenantAlignment<T = unknown>(tenantFilter?: string): Promise<T> {
+    return this.request<T>(
+      'GET',
+      'ListTenantAlignment',
+      tenantFilter ? { tenantFilter } : undefined
+    );
+  }
+
+  /**
    * Retrieve Best Practice Analyser (BPA) results for a tenant.
    * Calls the `ListBPA` Azure Function.
    *

--- a/tests/cipp.service.standards.test.ts
+++ b/tests/cipp.service.standards.test.ts
@@ -147,4 +147,18 @@ describe('CippService standards template tooling', () => {
       expect(fetchMock).not.toHaveBeenCalled();
     }
   );
+
+  it('deleteStandardTemplate POSTs RemoveStandardTemplate with the template ID', async () => {
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+      () => Promise.resolve(jsonResponse({ Results: 'deleted' }))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await svc.deleteStandardTemplate('guid-123');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(new URL(url).pathname).toMatch(/\/api\/RemoveStandardTemplate$/);
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({ ID: 'guid-123' });
+  });
 });

--- a/tests/cipp.service.standards.test.ts
+++ b/tests/cipp.service.standards.test.ts
@@ -1,0 +1,100 @@
+// Tests for CippService Standards Template tooling.
+import { CippService } from '../src/services/cipp.service.js';
+import { Logger } from '../src/utils/logger.js';
+
+const logger = new Logger('error');
+
+function jsonResponse(payload: unknown): Response {
+  const text = JSON.stringify(payload);
+  return {
+    ok: true,
+    status: 200,
+    text: async () => text,
+    json: async () => JSON.parse(text),
+  } as unknown as Response;
+}
+
+describe('CippService standards template tooling', () => {
+  let svc: CippService;
+
+  beforeEach(() => {
+    svc = new CippService(
+      { cipp: { baseUrl: 'https://cipp.example', apiKey: 'test-key' } },
+      logger
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('listStandardTemplates issues a GET to listStandardTemplates', async () => {
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+      () => Promise.resolve(jsonResponse([{ GUID: 't1' }]))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await svc.listStandardTemplates();
+
+    expect(result).toEqual([{ GUID: 't1' }]);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(new URL(url).pathname).toMatch(/\/api\/listStandardTemplates$/);
+    expect(init.method).toBe('GET');
+  });
+
+  it('getTenantDrift GETs ListTenantDrift scoped to a tenant when given one', async () => {
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+      () => Promise.resolve(jsonResponse([]))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await svc.getTenantDrift('contoso.com');
+
+    const [url] = fetchMock.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.pathname).toMatch(/\/api\/ListTenantDrift$/);
+    expect(parsed.searchParams.get('tenantFilter')).toBe('contoso.com');
+  });
+
+  it('getTenantDrift omits tenantFilter when no tenant is given', async () => {
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+      () => Promise.resolve(jsonResponse([]))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await svc.getTenantDrift();
+
+    const [url] = fetchMock.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.pathname).toMatch(/\/api\/ListTenantDrift$/);
+    expect(parsed.searchParams.has('tenantFilter')).toBe(false);
+  });
+
+  it('getTenantAlignment GETs ListTenantAlignment scoped to a tenant when given one', async () => {
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+      () => Promise.resolve(jsonResponse([]))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await svc.getTenantAlignment('contoso.com');
+
+    const [url] = fetchMock.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.pathname).toMatch(/\/api\/ListTenantAlignment$/);
+    expect(parsed.searchParams.get('tenantFilter')).toBe('contoso.com');
+  });
+
+  it('getTenantAlignment omits tenantFilter when no tenant is given', async () => {
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+      () => Promise.resolve(jsonResponse([]))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await svc.getTenantAlignment();
+
+    const [url] = fetchMock.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.pathname).toMatch(/\/api\/ListTenantAlignment$/);
+    expect(parsed.searchParams.has('tenantFilter')).toBe(false);
+  });
+});

--- a/tests/cipp.service.standards.test.ts
+++ b/tests/cipp.service.standards.test.ts
@@ -97,4 +97,54 @@ describe('CippService standards template tooling', () => {
     expect(parsed.pathname).toMatch(/\/api\/ListTenantAlignment$/);
     expect(parsed.searchParams.has('tenantFilter')).toBe(false);
   });
+
+  it('createStandardTemplate POSTs the template body to AddStandardsTemplate intact', async () => {
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+      () => Promise.resolve(jsonResponse({ Results: 'ok' }))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const template = {
+      templateName: 'WYRE Baseline',
+      tenantFilter: [{ value: 'AllTenants' }],
+      standards: { someStandard: {} },
+    };
+    await svc.createStandardTemplate(template);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(new URL(url).pathname).toMatch(/\/api\/AddStandardsTemplate$/);
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual(template);
+  });
+
+  it('createStandardTemplate rejects a template missing tenantFilter without calling CIPP', async () => {
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+      () => Promise.resolve(jsonResponse({}))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      svc.createStandardTemplate({ templateName: 'no assignment' })
+    ).rejects.toThrow(/must include a "tenantFilter"/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['null', null],
+    ['an array', []],
+    ['a primitive string', 'bad-input'],
+  ] as const)(
+    'createStandardTemplate rejects a non-object template (%s)',
+    async (_label, badInput) => {
+      const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+        () => Promise.resolve(jsonResponse({}))
+      );
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(
+        svc.createStandardTemplate(badInput as unknown as Record<string, unknown>)
+      ).rejects.toThrow(/JSON object/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  );
 });


### PR DESCRIPTION
Implements docs/superpowers/specs/2026-05-20-cipp-standards-tooling-design.md — five MCP tools to manage CIPP Standards Templates and report tenant drift/alignment. Phase 1 of the standards baseline effort.