### PR TITLE
chore: add glama.json for ownership claim

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["asachs01"]
+}


### PR DESCRIPTION
Adds glama.json so this server's Glama.ai listing can be claimed by an org maintainer. See wyre-technology/.github#17 for context. Mirrors the file already present in autotask-mcp.