### PR TITLE
build(deps-dev): adopt TypeScript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "semantic-release": "^25.0.0",
         "ts-jest": "^29.1.1",
         "tsx": "^4.6.0",
-        "typescript": "^5.3.0"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -12401,9 +12401,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "semantic-release": "^25.0.0",
     "ts-jest": "^29.1.1",
     "tsx": "^4.6.0",
-    "typescript": "^5.3.0",
+    "typescript": "^6.0.3",
     "@semantic-release/github": "^11.0.0"
   },
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": [
+      "ES2020"
+    ],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
@@ -19,8 +21,19 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": [
+      "node"
+    ],
+    "ignoreDeprecations": "6.0"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
 }


### PR DESCRIPTION
Fleet TS6 migration (tracker: wyre-technology/mcp-gateway#221). Applied via the ts6-fleet-migration codemod: `types:["node"]` + `ignoreDeprecations:"6.0"` as needed, `typescript ^6.0.3`. Local typecheck (`build`) passed; CI runs full build/test.