### PR TITLE
docs: point CIPP_BASE_URL at the Azure Function App, not the SWA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 # CIPP MCP Server Configuration
-CIPP_BASE_URL=https://cipp.yourdomain.com
+#
+# CIPP_BASE_URL must be the CIPP-API Azure Function App URL
+# (https://<function-app-name>.azurewebsites.net), NOT the Static Web App /
+# custom-domain UI URL (e.g. https://cipp.yourdomain.com). The SWA redirects
+# bearer-token requests to its interactive login page, so API calls fail.
+CIPP_BASE_URL=https://cippXXXXX.azurewebsites.net
 
 # --- Authentication (choose ONE) -------------------------------------------
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alignment. This lets a standards baseline be managed as code.
 
 ### Fixed
+- Documentation pointed `CIPP_BASE_URL` at the Static Web App / custom-domain
+  UI URL (`https://cipp.yourdomain.com`). The SWA's built-in auth redirects
+  bearer-token requests to its interactive login page, so every API call
+  fails. All examples (README, `.env.example`, `smithery.yaml`,
+  `manifest.json`, `docker-compose.yml`) now use the CIPP-API Azure Function
+  App URL (`https://<function-app-name>.azurewebsites.net`) and the README
+  explains the distinction.
 - `cipp_list_domain_health` returned no data — it called CIPP's
   `ListDomainHealth` function with only `tenantFilter`. That function is a
   per-domain DNS helper requiring `Action` + `Domain` query parameters and

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Set these environment variables (or copy `.env.example` to `.env`):
 
 | Variable | Required | Description |
 |---|---|---|
-| `CIPP_BASE_URL` | Yes | Your CIPP deployment URL (e.g. `https://cipp.yourdomain.com`) |
+| `CIPP_BASE_URL` | Yes | Your CIPP-API **Azure Function App** URL (e.g. `https://cippXXXXX.azurewebsites.net`) — see note below |
 | `CIPP_API_KEY` | One of | Static Bearer token. Use this **or** the OAuth trio below. |
 | `CIPP_TENANT_ID` | One of | Entra tenant ID that owns the CIPP API-client app registration. |
 | `CIPP_CLIENT_ID` | One of | OAuth client ID issued by CIPP's API Client Management page. |
@@ -53,6 +53,14 @@ Set these environment variables (or copy `.env.example` to `.env`):
 | `MCP_TRANSPORT` | No | `stdio` (default) or `http` |
 | `MCP_HTTP_PORT` | No | Port for HTTP mode (default: 8080) |
 | `LOG_LEVEL` | No | `error`, `warn`, `info` (default), or `debug` |
+
+> [!IMPORTANT]
+> `CIPP_BASE_URL` must be the **Azure Function App** URL — the CIPP-API backend,
+> `https://<function-app-name>.azurewebsites.net` — **not** the Static Web App /
+> custom-domain UI URL (e.g. `https://cipp.yourdomain.com`). The SWA's built-in
+> auth intercepts bearer tokens and redirects them to its interactive login page,
+> so every API call fails. Find the Function App (named like `cippXXXXX`) in your
+> CIPP resource group in the Azure Portal.
 
 ## Usage with Claude Desktop
 
@@ -65,7 +73,7 @@ Add to your `claude_desktop_config.json`:
       "command": "node",
       "args": ["/path/to/cipp-mcp/dist/entry.js"],
       "env": {
-        "CIPP_BASE_URL": "https://cipp.yourdomain.com",
+        "CIPP_BASE_URL": "https://cippXXXXX.azurewebsites.net",
         "CIPP_API_KEY": "your-api-key"
       }
     }
@@ -103,7 +111,7 @@ its expiry.
    retrieve the secret later
 4. Configure the server:
    ```env
-   CIPP_BASE_URL=https://cipp.yourdomain.com
+   CIPP_BASE_URL=https://cippXXXXX.azurewebsites.net
    CIPP_TENANT_ID=<your-entra-tenant-id>
    CIPP_CLIENT_ID=<client-id-from-cipp>
    CIPP_CLIENT_SECRET=<client-secret-from-cipp>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ volumes:
     driver: local
 
 # Example .env file structure (create this file with your actual credentials):
-# CIPP_BASE_URL=https://cipp.yourdomain.com
+# CIPP_BASE_URL=https://cippXXXXX.azurewebsites.net   # Function App URL, not the SWA UI URL
 # CIPP_API_KEY=your-api-key-here
 # LOG_LEVEL=info
 # LOG_FORMAT=json

--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,7 @@
     "cipp_base_url": {
       "type": "string",
       "title": "CIPP Base URL",
-      "description": "The base URL of your CIPP deployment (e.g. https://cipp.yourdomain.com)",
+      "description": "The CIPP-API Azure Function App URL (e.g. https://cippXXXXX.azurewebsites.net). Do NOT use the Static Web App / custom-domain UI URL — it redirects bearer tokens to interactive login.",
       "required": true
     },
     "cipp_api_key": {

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -8,7 +8,10 @@ startCommand:
     properties:
       cippBaseUrl:
         type: string
-        description: The base URL of your CIPP deployment (e.g. https://cipp.yourdomain.com)
+        description: |
+          The CIPP-API Azure Function App URL (e.g.
+          https://cippXXXXX.azurewebsites.net). Do NOT use the Static Web App /
+          custom-domain UI URL — it redirects bearer tokens to interactive login.
       cippApiKey:
         type: string
         description: |


### PR DESCRIPTION
## Summary

All configuration examples pointed `CIPP_BASE_URL` at the Static Web App / custom-domain UI URL (`https://cipp.yourdomain.com`). That URL's built-in auth intercepts bearer-token requests and 302s them to `/.auth/login/aad`, so every API call fails with a 401/403.

External API clients must hit the CIPP-API **Azure Function App** URL directly (`https://<function-app-name>.azurewebsites.net`). The source already said so (`src/utils/config.ts`) — the user-facing docs didn't.

## Changes

- **README.md** — env-var table, Claude Desktop example, and auth-setup example now use `https://cippXXXXX.azurewebsites.net`; added an IMPORTANT callout explaining the SWA-vs-Function-App distinction and where to find the Function App URL
- **.env.example** — corrected example URL + explanatory comment
- **smithery.yaml** / **manifest.json** — `cippBaseUrl` / `cipp_base_url` field descriptions corrected
- **docker-compose.yml** — example `.env` comment corrected
- **CHANGELOG.md** — entry under Unreleased → Fixed

Matches the guidance already in `mcp-gateway/docs/vendors/cipp.md` and the gateway's `vendor-config.ts` placeholder.