### PR TITLE
ci: centralize release pipeline via reusable mcp-server-release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,213 +2,41 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
-      - next
-      - next-major
-      - beta
-      - alpha
+    branches: [main]
   pull_request:
-    branches:
-      - main
+    branches: [main]
 
+# Thin caller for the canonical reusable release pipeline. The build →
+# semantic-release → Docker → MCP Registry → security chain (tag-based release
+# detection + correct gating) lives in wyre-technology/.github so every *-mcp
+# repo stays in lockstep instead of drifting per-repo. PR-time lint/test gating
+# is each repo's ci.yml concern; this workflow only runs the release path.
+# Caller jobs grant the token scopes the reusable jobs request (a reusable can
+# only reduce, never expand, caller-granted scope).
 jobs:
-  test:
-    name: Test
-    # Delegated to the canonical reusable CI workflow.
-    # See: ~/.claude/skills/mcp-server-fleet-ci-template
-    uses: wyre-technology/.github/.github/workflows/mcp-server-ci.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0
-    with:
-      node-versions: '["18", "20", "22"]'
-      lint-destructive-warnings: true
-    secrets: inherit
-
   release:
-    name: Release
-    needs: test
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       contents: write
       issues: write
-      pull-requests: write
       packages: write
-    outputs:
-      version: ${{ steps.release-version.outputs.version }}
-      released: ${{ steps.release-version.outputs.released }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+      id-token: write
+      security-events: write
+    uses: wyre-technology/.github/.github/workflows/mcp-server-release.yml@7794e75666ac4956274f7a7d25dabacd56c96bbc
+    with:
+      server-name: cipp-mcp
+      image-name: ghcr.io/wyre-technology/cipp-mcp
+    secrets: inherit
 
-      - name: Use Node.js 22
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
-        with:
-          node-version: 22.x
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Capture pre-release version
-        run: |
-          PRE_VERSION=$(node -p "require('./package.json').version")
-          echo "PRE_VERSION=$PRE_VERSION" >> "$GITHUB_ENV"
-
-      - name: Semantic Release
-        run: npx semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get released version
-        id: release-version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          if [ "$VERSION" != "$PRE_VERSION" ]; then
-            echo "released=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "released=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  docker:
-    name: Build and Push Docker Image
-    needs: [release]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    permissions:
-      contents: read
-      packages: write
-    outputs:
-      digest: ${{ steps.push.outputs.digest }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Resolve release version
-        id: version
-        env:
-          RELEASE_VERSION: ${{ needs.release.outputs.version }}
-        run: |
-          if [ -z "$RELEASE_VERSION" ]; then
-            echo "ERROR: needs.release.outputs.version is empty" >&2
-            exit 1
-          fi
-          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=v${{ steps.version.outputs.version }}
-            type=sha,prefix=sha-
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392  # v3.6.0
-
-      - name: Build and push
-        id: push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6.19.2
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ steps.version.outputs.version }}
-            COMMIT_SHA=${{ github.sha }}
-            BUILD_DATE=${{ github.event.repository.updated_at }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-  mcp-registry:
-    name: Publish to MCP Registry
-    runs-on: ubuntu-latest
-    needs: [release, docker]
+  deploy:
+    needs: release
     if: needs.release.outputs.released == 'true'
     permissions:
       id-token: write
       contents: read
-    env:
-      VERSION: ${{ needs.release.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - name: Install mcp-publisher
-        run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
-            | tar xz mcp-publisher
-      - name: Stamp version into server.json
-        run: |
-          jq --arg v "$VERSION" \
-            '.version = $v | .packages[0].identifier = "ghcr.io/wyre-technology/cipp-mcp:v" + $v' \
-            server.json > server.json.tmp
-          mv server.json.tmp server.json
-          cat server.json
-      - name: Validate server.json
-        run: ./mcp-publisher validate
-      - name: Authenticate to MCP Registry (GitHub OIDC)
-        run: ./mcp-publisher login github-oidc
-      - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
-      - name: Verify registry listing
-        run: |
-          sleep 5
-          curl -sf "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.wyre-technology/cipp-mcp" \
-            | jq '.servers[]?.server | {name, version}'
-
-  security:
-    name: Security Scan
-    needs: docker
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    permissions:
-      security-events: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ghcr.io/${{ github.repository }}:latest
-          format: sarif
-          output: trivy-results.sarif
-
-      - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@0daab03d71ff584ef619d027a3fd9146679c5d84  # v3.35.3
-        with:
-          sarif_file: trivy-results.sarif
-
-  deploy:
-    name: Deploy to Azure Container Apps
-    needs: [release, docker]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      id-token: write
-      contents: read
-    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@198605d0575e27374cf9b67fba3aa8c7b91de2c0
+    uses: wyre-technology/.github/.github/workflows/mcp-server-deploy.yml@7794e75666ac4956274f7a7d25dabacd56c96bbc
     with:
       vendor-slug: cipp
       image-name: ghcr.io/wyre-technology/cipp-mcp
-      digest: ${{ needs.docker.outputs.digest }}
+      digest: ${{ needs.release.outputs.digest }}
       version: ${{ needs.release.outputs.version }}
     secrets: inherit


### PR DESCRIPTION
Replaces the inline release/docker/mcp-registry/deploy jobs with a thin caller of the reusable workflows in wyre-technology/.github (release via mcp-server-release.yml, deploy via mcp-server-deploy.yml). Fixes the 'duplicate version' MCP Registry failure from the old gh-release-view gating; release detection is now tag-based. Proven on domotz-mcp#27. Part of the fleet-wide centralization. vendor-slug=cipp.