### PR TITLE
feat(tools): add cipp_list_enterprise_apps for per-tenant SaaS audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `cipp_list_enterprise_apps` tool — list enterprise applications
+  (service principals) in a tenant via the CIPP `ListGraphRequest`
+  passthrough against the `/servicePrincipals` Graph endpoint. Returns
+  `appId`, `displayName`, `publisherName`, `appOwnerOrganizationId`,
+  `signInAudience`, `tags`, and `createdDateTime`. Default filter
+  excludes Microsoft-built-in apps (owner-org `f8cdef31-…`); pass
+  `includeBuiltIn=true` to include them. Supports `tenantFilter='allTenants'`
+  for cross-tenant fan-out — CIPP returns per-tenant errors (e.g. 403 from
+  a tenant without GDAP delegated admin) as inline error rows rather than
+  failing the whole call. This is the data foundation for the per-tenant
+  SaaS-catalog audit (rank customer apps by tenant-frequency).
 - OAuth 2.0 client-credentials auth against Entra ID. CIPP's "API Clients"
   integration page issues a client ID + secret — the server now exchanges
   those for a short-lived access token per request and caches it until expiry.

--- a/src/handlers/tool.handler.ts
+++ b/src/handlers/tool.handler.ts
@@ -301,6 +301,18 @@ export class CippToolHandler {
         }
 
         // -----------------------------------------------------------------------
+        // Applications
+        // -----------------------------------------------------------------------
+        case 'cipp_list_enterprise_apps': {
+          const { tenantFilter, includeBuiltIn } = args as {
+            tenantFilter: string;
+            includeBuiltIn?: boolean;
+          };
+          result = await this.cippService.listEnterpriseApps(tenantFilter, { includeBuiltIn });
+          break;
+        }
+
+        // -----------------------------------------------------------------------
         // Standards
         // -----------------------------------------------------------------------
         case 'cipp_list_standards': {

--- a/src/mcp/tool.definitions.ts
+++ b/src/mcp/tool.definitions.ts
@@ -592,6 +592,27 @@ export const TOOL_DEFINITIONS: McpToolDefinition[] = [
   },
 
   // -------------------------------------------------------------------------
+  // Applications tools
+  // -------------------------------------------------------------------------
+  {
+    name: 'cipp_list_enterprise_apps',
+    description:
+      "List enterprise applications (service principals) in a tenant — including third-party SaaS apps that customers have integrated via OAuth (Slack, Salesforce, Zoom, etc.). Returns appId, displayName, publisher, owner-org, signInAudience, tags, and creation date. Use tenantFilter='allTenants' for cross-tenant fan-out — CIPP handles per-tenant errors inline, so a 403 from one opt-out tenant returns as an error row rather than failing the call. Excludes Microsoft-built-in apps by default (owner org f8cdef31-…); pass includeBuiltIn=true to include them.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tenantFilter: TENANT_FILTER_PROP,
+        includeBuiltIn: {
+          type: 'boolean',
+          description:
+            "When true, includes Microsoft-built-in service principals (owner org f8cdef31-a31e-4b4a-93e4-5f571e91255a). Defaults to false (third-party / customer-installed apps only).",
+        },
+      },
+      required: ['tenantFilter'],
+    },
+  },
+
+  // -------------------------------------------------------------------------
   // Standards tools
   // -------------------------------------------------------------------------
   {
@@ -935,6 +956,7 @@ export const TOOL_CATEGORIES: Record<string, string[]> = {
     'cipp_set_email_forwarding',
   ],
   security: ['cipp_list_conditional_access_policies', 'cipp_list_named_locations'],
+  applications: ['cipp_list_enterprise_apps'],
   standards: [
     'cipp_list_standards',
     'cipp_run_standards_check',

--- a/src/services/cipp.service.ts
+++ b/src/services/cipp.service.ts
@@ -845,4 +845,44 @@ export class CippService {
   async addScheduledItem<T = unknown>(itemData: Record<string, unknown>): Promise<T> {
     return this.request<T>('POST', 'AddScheduledItem', undefined, itemData);
   }
+
+  // -------------------------------------------------------------------------
+  // Applications
+  // -------------------------------------------------------------------------
+
+  /**
+   * List enterprise applications (service principals) in a tenant.
+   * Calls the `ListGraphRequest` Azure Function with the `/servicePrincipals` Graph endpoint.
+   *
+   * Used to discover third-party SaaS apps customers have integrated via OAuth
+   * (Slack, Salesforce, Zoom, etc.) — the foundation of the data-driven catalog
+   * audit that ranks customer SaaS apps by tenant-frequency.
+   *
+   * @param tenantFilter - Tenant domain or identifier, or 'allTenants' for cross-tenant fan-out.
+   * @param params - Optional filter parameters.
+   * @param params.includeBuiltIn - When true, includes Microsoft-built-in service principals
+   *   (owner org f8cdef31-a31e-4b4a-93e4-5f571e91255a). Defaults to false (third-party only).
+   *
+   * @remarks
+   * For `tenantFilter='allTenants'`, CIPP's `ListGraphRequest` backend handles the fan-out
+   * across all managed tenants server-side and represents per-tenant errors (e.g. 403 from a
+   * tenant that hasn't granted GDAP delegated admin) as inline error rows in the response —
+   * one opt-out does NOT fail the whole call.
+   */
+  async listEnterpriseApps<T = unknown>(
+    tenantFilter: string,
+    params?: { includeBuiltIn?: boolean }
+  ): Promise<T> {
+    const MICROSOFT_OWNER_ORG_ID = 'f8cdef31-a31e-4b4a-93e4-5f571e91255a';
+    const query: Record<string, unknown> = {
+      tenantFilter,
+      Endpoint: '/servicePrincipals',
+      $select:
+        'appId,displayName,publisherName,appOwnerOrganizationId,signInAudience,tags,createdDateTime',
+    };
+    if (!params?.includeBuiltIn) {
+      query.$filter = `appOwnerOrganizationId ne ${MICROSOFT_OWNER_ORG_ID}`;
+    }
+    return this.request<T>('GET', 'ListGraphRequest', query);
+  }
 }

--- a/tests/cipp.service.enterprise-apps.test.ts
+++ b/tests/cipp.service.enterprise-apps.test.ts
@@ -1,0 +1,102 @@
+// Tests for CippService listEnterpriseApps — the per-tenant servicePrincipals
+// audit tool that powers the data-driven catalog candidate ranking.
+import { CippService } from '../src/services/cipp.service.js';
+import { Logger } from '../src/utils/logger.js';
+
+const logger = new Logger('error');
+
+function jsonResponse(payload: unknown): Response {
+  const text = JSON.stringify(payload);
+  return {
+    ok: true,
+    status: 200,
+    text: async () => text,
+    json: async () => JSON.parse(text),
+  } as unknown as Response;
+}
+
+describe('CippService enterprise apps tooling', () => {
+  let svc: CippService;
+
+  beforeEach(() => {
+    svc = new CippService(
+      { cipp: { baseUrl: 'https://cipp.example', apiKey: 'test-key' } },
+      logger
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('listEnterpriseApps GETs ListGraphRequest with tenantFilter + /servicePrincipals endpoint + third-party filter by default', async () => {
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+      () => Promise.resolve(jsonResponse([{ appId: 'a1', displayName: 'Slack' }]))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await svc.listEnterpriseApps('contoso.com');
+
+    expect(result).toEqual([{ appId: 'a1', displayName: 'Slack' }]);
+    const [url, init] = fetchMock.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.pathname).toMatch(/\/api\/ListGraphRequest$/);
+    expect(init.method).toBe('GET');
+    expect(parsed.searchParams.get('tenantFilter')).toBe('contoso.com');
+    expect(parsed.searchParams.get('Endpoint')).toBe('/servicePrincipals');
+    expect(parsed.searchParams.get('$select')).toBe(
+      'appId,displayName,publisherName,appOwnerOrganizationId,signInAudience,tags,createdDateTime'
+    );
+    // Default third-party filter — exclude Microsoft built-in (owner org f8cdef31-…)
+    expect(parsed.searchParams.get('$filter')).toBe(
+      'appOwnerOrganizationId ne f8cdef31-a31e-4b4a-93e4-5f571e91255a'
+    );
+  });
+
+  it('listEnterpriseApps omits $filter when includeBuiltIn=true', async () => {
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+      () => Promise.resolve(jsonResponse([]))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await svc.listEnterpriseApps('contoso.com', { includeBuiltIn: true });
+
+    const [url] = fetchMock.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has('$filter')).toBe(false);
+    expect(parsed.searchParams.get('Endpoint')).toBe('/servicePrincipals');
+  });
+
+  it('listEnterpriseApps passes tenantFilter=allTenants through for CIPP-side fan-out', async () => {
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+      () => Promise.resolve(jsonResponse([{ Tenant: 'contoso.com', appId: 'a1' }]))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await svc.listEnterpriseApps('allTenants');
+
+    expect(result).toEqual([{ Tenant: 'contoso.com', appId: 'a1' }]);
+    const [url] = fetchMock.mock.calls[0];
+    expect(new URL(url).searchParams.get('tenantFilter')).toBe('allTenants');
+  });
+
+  it('listEnterpriseApps surfaces an inline error row from CIPP for a tenant 403 without throwing', async () => {
+    // CIPP's allTenants fan-out behavior: per-tenant errors are returned as inline
+    // entries in the result array, NOT as an HTTP error. The pass-through preserves that shape.
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(
+      () => Promise.resolve(
+        jsonResponse([
+          { Tenant: 'contoso.com', appId: 'a1', displayName: 'Slack' },
+          { Tenant: 'fabrikam.com', error: 'Forbidden — GDAP not granted' },
+        ])
+      )
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = (await svc.listEnterpriseApps('allTenants')) as Array<Record<string, unknown>>;
+
+    expect(result).toHaveLength(2);
+    expect(result[0].Tenant).toBe('contoso.com');
+    expect(result[1].error).toBe('Forbidden — GDAP not granted');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `cipp_list_enterprise_apps` — a new MCP tool that lists enterprise applications (service principals) in a tenant via CIPP's existing `ListGraphRequest` passthrough against the `/servicePrincipals` Graph endpoint. Returns `appId`, `displayName`, `publisherName`, `appOwnerOrganizationId`, `signInAudience`, `tags`, and `createdDateTime`.

This unblocks a per-tenant SaaS-catalog audit: fan out `tenantFilter='allTenants'` across the 35 managed tenants, aggregate appId/displayName occurrences, and rank by tenant-frequency to surface the SaaS integrations customers actually use — the data foundation for the launch catalog beyond the obvious first-batch 6.

## Why this shape (not a gateway-direct GDAP Graph proxy)

CIPP already does per-tenant GDAP token swap server-side for all 35 tenants via the same `ListGraphRequest` endpoint used by CIPP's own graph-explorer page and `ListSecurescore`. Going direct from the gateway would require duplicating the partner-center GDAP relationship + per-tenant token acquisition + Graph client wiring — ~20-40h vs. ~2-4h of passthrough.

## Behavior

- **Default**: `$filter=appOwnerOrganizationId ne f8cdef31-a31e-4b4a-93e4-5f571e91255a` excludes Microsoft-built-in apps; only customer-installed third-party apps are returned.
- **`includeBuiltIn=true`**: omits the `$filter` so Microsoft built-ins are included.
- **`tenantFilter='allTenants'`**: CIPP backend handles the cross-tenant fan-out. Per-tenant errors (e.g. 403 from a tenant without GDAP delegated admin) come back as inline error rows in the response array, not as a top-level HTTP error — one opt-out doesn't fail the whole call.

## Files

- `src/mcp/tool.definitions.ts` — new `cipp_list_enterprise_apps` definition + new `applications` TOOL_GROUPS category
- `src/handlers/tool.handler.ts` — dispatch case
- `src/services/cipp.service.ts` — `listEnterpriseApps(tenantFilter, { includeBuiltIn? })` method
- `tests/cipp.service.enterprise-apps.test.ts` — 4 test cases
- `CHANGELOG.md` — `[Unreleased] / Added` entry

## Tests

- 4 new cases (default filter, `includeBuiltIn=true`, `allTenants` pass-through, inline-error-row handling)
- 21/21 total tests pass; TypeScript build clean; ESLint clean

## Test plan
- [ ] Smoke against WYRE's CIPP (`cipp.wyretechnology.com`) with a single tenant + verify third-party apps appear
- [ ] Smoke with `tenantFilter='allTenants'` + verify response includes inline error rows for any opt-out tenants
- [ ] Run aggregation step (out of scope for this PR) to confirm the audit ranking works end-to-end