### PR TITLE
fix(security): SHA-pin auto-add-to-project.yml @main -> @6ae1533dd72f (warden C-4)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   call:
-    uses: wyre-technology/.github/.github/workflows/auto-add-to-project.yml@main
+    uses: wyre-technology/.github/.github/workflows/auto-add-to-project.yml@6ae1533dd72f080d81b9842c22646d254b8d5e01  # pinned (warden C-4) — bump via PR not in-place edit
     secrets: inherit


### PR DESCRIPTION
## Summary

Replaces `@main` mutable-reference with canonical SHA `6ae1533dd72f080d81b9842c22646d254b8d5e01` from `wyre-technology/.github` main, per warden CI/CD audit 2026-06-22 (C-4, pre-6/29 fix).

**Why:** `@main` lets a push to the `.github` repo's main instant-propagate across the entire caller fleet with no rollback window. SHA-pin makes future bumps explicit + reviewable + auditable.

## Test plan

- [x] One-line edit in `.github/workflows/` — sed-applied + diff inspected
- [x] CI no-op (workflow only runs on issue/PR-open events; this is a metadata pin)

## Docs (Definition-of-Done per Aaron 2026-06-21)

- [x] Exempt because: pure-internal CI workflow SHA-pin; no customer-visible or operator-relevant behavior change.

## References

- warden audit: `warden/deliverables/2026-06-22-cicd-supply-chain-audit-part1.md` (C-4 line 100)
- Canonical SHA source: https://github.com/wyre-technology/.github/commit/6ae1533dd72f080d81b9842c22646d254b8d5e01
- Fleet rollout: ~29 caller repos, one PR each per delegation rubric