### PR TITLE
fix: ignore unresolved config placeholders in credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alignment. This lets a standards baseline be managed as code.
 
 ### Fixed
+- Unresolved MCPB/DXT config placeholders in credentials no longer break auth.
+  Desktop bundles map env vars to `${user_config.X}` in `manifest.json`; when an
+  optional field (e.g. the API key) is left blank the host injects the literal
+  string `${user_config.cipp_api_key}` rather than an empty value. Because that
+  literal is truthy, it silently overrode the OAuth client-credentials path and
+  was sent as `Authorization: Bearer ${user_config.cipp_api_key}`, 401'ing every
+  request. Credentials are now sanitised at ingress (`cleanCredential` /
+  `sanitizeCredentials` in `src/utils/config.ts`) so empty, whitespace-only, and
+  `${...}` placeholder values are treated as absent across all sources (env vars,
+  gateway env promotion, and HTTP headers). Mirrors itglue-mcp #73.
 - Documentation pointed `CIPP_BASE_URL` at the Static Web App / custom-domain
   UI URL (`https://cipp.yourdomain.com`). The SWA's built-in auth redirects
   bearer-token requests to its interactive login page, so every API call

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -77,6 +77,53 @@ export interface GatewayCredentials {
   tokenUrl: string | undefined;
 }
 
+// An unresolved MCPB/DXT manifest placeholder, e.g. "${user_config.cipp_api_key}".
+// Desktop hosts (Claude Desktop) inject the config template verbatim when its
+// optional user_config field is left blank, so the literal string arrives in the
+// env var / header rather than an empty value or an omitted key.
+const CONFIG_PLACEHOLDER = /^\$\{.*\}$/;
+
+/**
+ * Normalise a single credential read from an env var or gateway header.
+ *
+ * Returns `undefined` for values that are effectively absent, so the auth layer
+ * treats them as "no credential" rather than a real secret:
+ *   - undefined / empty / whitespace-only
+ *   - an unresolved manifest placeholder like `${user_config.cipp_api_key}`
+ *
+ * Root cause of the itglue-mcp #73 pattern: CIPP supports two auth modes — a
+ * static Bearer API key OR OAuth client-credentials. A user configuring OAuth
+ * leaves the optional API-key field blank, which leaves the literal
+ * `${user_config.cipp_api_key}` in `CIPP_API_KEY`. Because that string is
+ * truthy, `CippService` (see the `if (!apiKey && tenantId && clientId &&
+ * clientSecret)` guard) never builds the OAuth `TokenProvider` and instead
+ * sends `Authorization: Bearer ${user_config.cipp_api_key}` on every request —
+ * a guaranteed 401. Stripping the placeholder here lets the OAuth path engage.
+ */
+export function cleanCredential(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || CONFIG_PLACEHOLDER.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+/**
+ * Sanitise every field of a credential set at ingress, dropping empty and
+ * unresolved-placeholder values. Applied to all credential sources (gateway env
+ * vars, HTTP headers, and direct env reads) so a placeholder never reaches the
+ * auth layer as a secret.
+ */
+export function sanitizeCredentials(creds: GatewayCredentials): GatewayCredentials {
+  return {
+    apiKey: cleanCredential(creds.apiKey),
+    baseUrl: cleanCredential(creds.baseUrl),
+    tenantId: cleanCredential(creds.tenantId),
+    clientId: cleanCredential(creds.clientId),
+    clientSecret: cleanCredential(creds.clientSecret),
+    tokenScope: cleanCredential(creds.tokenScope),
+    tokenUrl: cleanCredential(creds.tokenUrl),
+  };
+}
+
 /**
  * Extract CIPP credentials from gateway-injected environment variables.
  *
@@ -85,7 +132,7 @@ export interface GatewayCredentials {
  * - `X-Base-Url` header →  `X_BASE_URL` env var (falls back to `CIPP_BASE_URL`)
  */
 export function getCredentialsFromGateway(): GatewayCredentials {
-  return {
+  return sanitizeCredentials({
     apiKey: process.env.X_API_KEY || process.env.CIPP_API_KEY,
     baseUrl: process.env.X_BASE_URL || process.env.CIPP_BASE_URL,
     tenantId: process.env.X_TENANT_ID || process.env.CIPP_TENANT_ID,
@@ -93,7 +140,7 @@ export function getCredentialsFromGateway(): GatewayCredentials {
     clientSecret: process.env.X_CLIENT_SECRET || process.env.CIPP_CLIENT_SECRET,
     tokenScope: process.env.X_TOKEN_SCOPE || process.env.CIPP_TOKEN_SCOPE,
     tokenUrl: process.env.X_TOKEN_URL || process.env.CIPP_TOKEN_URL,
-  };
+  });
 }
 
 /**
@@ -113,7 +160,7 @@ export function parseCredentialsFromHeaders(
     return Array.isArray(value) ? value[0] : value;
   };
 
-  return {
+  return sanitizeCredentials({
     apiKey: getHeader('x-api-key'),
     baseUrl: getHeader('x-base-url'),
     tenantId: getHeader('x-tenant-id'),
@@ -121,7 +168,7 @@ export function parseCredentialsFromHeaders(
     clientSecret: getHeader('x-client-secret'),
     tokenScope: getHeader('x-token-scope'),
     tokenUrl: getHeader('x-token-url'),
-  };
+  });
 }
 
 /**
@@ -156,7 +203,7 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
   // falls back to CIPP_* vars internally, so it is safe to call in both modes.
   const creds: GatewayCredentials = authMode === 'gateway'
     ? getCredentialsFromGateway()
-    : {
+    : sanitizeCredentials({
         apiKey: process.env.CIPP_API_KEY,
         baseUrl: process.env.CIPP_BASE_URL,
         tenantId: process.env.CIPP_TENANT_ID,
@@ -164,7 +211,7 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
         clientSecret: process.env.CIPP_CLIENT_SECRET,
         tokenScope: process.env.CIPP_TOKEN_SCOPE,
         tokenUrl: process.env.CIPP_TOKEN_URL,
-      };
+      });
 
   // Build the cipp sub-object, omitting undefined values so that
   // exactOptionalPropertyTypes is satisfied in strict tsconfig setups.

--- a/tests/config.placeholder.test.ts
+++ b/tests/config.placeholder.test.ts
@@ -1,0 +1,179 @@
+// Regression tests for the itglue-mcp #73 "unresolved MCPB config placeholder"
+// pattern applied to cipp-mcp.
+//
+// MCPB/DXT desktop bundles map env vars to `${user_config.X}` in manifest.json.
+// When an OPTIONAL user_config field is left blank, Claude Desktop injects the
+// LITERAL string `${user_config.X}` into the env var — not empty, not omitted.
+//
+// CIPP supports two auth modes: a static Bearer API key OR OAuth
+// client-credentials. A user who configures OAuth and leaves the optional API
+// key blank ends up with `CIPP_API_KEY="${user_config.cipp_api_key}"`. Because
+// that literal is truthy, CippService's `if (!apiKey && tenantId && clientId &&
+// clientSecret)` guard never builds the OAuth TokenProvider and instead sends
+// `Authorization: Bearer ${user_config.cipp_api_key}` — a guaranteed 401 on
+// every request. Sanitising credentials at ingress fixes it.
+
+import {
+  cleanCredential,
+  sanitizeCredentials,
+  getCredentialsFromGateway,
+  parseCredentialsFromHeaders,
+  loadEnvironmentConfig,
+  mergeWithMcpConfig,
+} from '../src/utils/config.js';
+import { CippService } from '../src/services/cipp.service.js';
+import { Logger } from '../src/utils/logger.js';
+
+const logger = new Logger('error');
+const API_KEY_PLACEHOLDER = '${user_config.cipp_api_key}';
+
+describe('cleanCredential', () => {
+  it('drops undefined, empty, and whitespace-only values', () => {
+    expect(cleanCredential(undefined)).toBeUndefined();
+    expect(cleanCredential('')).toBeUndefined();
+    expect(cleanCredential('   ')).toBeUndefined();
+  });
+
+  it('drops unresolved ${user_config.X} manifest placeholders', () => {
+    expect(cleanCredential(API_KEY_PLACEHOLDER)).toBeUndefined();
+    expect(cleanCredential('  ${user_config.cipp_api_key}  ')).toBeUndefined();
+    expect(cleanCredential('${user_config.cipp_client_secret}')).toBeUndefined();
+  });
+
+  it('preserves and trims real credentials', () => {
+    expect(cleanCredential('real-api-key')).toBe('real-api-key');
+    expect(cleanCredential('  real-api-key  ')).toBe('real-api-key');
+  });
+});
+
+describe('sanitizeCredentials', () => {
+  it('strips placeholder fields while keeping real ones', () => {
+    const cleaned = sanitizeCredentials({
+      apiKey: API_KEY_PLACEHOLDER,
+      baseUrl: 'https://cipp.example',
+      tenantId: 'tenant-123',
+      clientId: 'client-abc',
+      clientSecret: 'secret-xyz',
+      tokenScope: undefined,
+      tokenUrl: '   ',
+    });
+
+    expect(cleaned.apiKey).toBeUndefined();
+    expect(cleaned.tokenUrl).toBeUndefined();
+    expect(cleaned.baseUrl).toBe('https://cipp.example');
+    expect(cleaned.tenantId).toBe('tenant-123');
+    expect(cleaned.clientId).toBe('client-abc');
+    expect(cleaned.clientSecret).toBe('secret-xyz');
+  });
+});
+
+describe('issue #73: unresolved MCPB placeholders at credential ingress', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    // Ensure a clean slate for CIPP_* / X_* between cases.
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('CIPP_') || key.startsWith('X_')) {
+        delete process.env[key];
+      }
+    }
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('loadEnvironmentConfig ignores a placeholder API key but keeps OAuth creds', () => {
+    process.env.CIPP_BASE_URL = 'https://cipp.example';
+    process.env.CIPP_API_KEY = API_KEY_PLACEHOLDER; // optional field left blank
+    process.env.CIPP_TENANT_ID = 'tenant-123';
+    process.env.CIPP_CLIENT_ID = 'client-abc';
+    process.env.CIPP_CLIENT_SECRET = 'secret-xyz';
+
+    const { cipp } = loadEnvironmentConfig();
+
+    // The placeholder must NOT survive as a real Bearer token...
+    expect(cipp.apiKey).toBeUndefined();
+    // ...and the OAuth fields must remain so the token provider can be built.
+    expect(cipp.tenantId).toBe('tenant-123');
+    expect(cipp.clientId).toBe('client-abc');
+    expect(cipp.clientSecret).toBe('secret-xyz');
+  });
+
+  it('getCredentialsFromGateway (env/header promotion) drops a placeholder API key', () => {
+    process.env.X_API_KEY = API_KEY_PLACEHOLDER;
+    process.env.X_TENANT_ID = 'tenant-123';
+    process.env.X_CLIENT_ID = 'client-abc';
+    process.env.X_CLIENT_SECRET = 'secret-xyz';
+
+    const creds = getCredentialsFromGateway();
+
+    expect(creds.apiKey).toBeUndefined();
+    expect(creds.tenantId).toBe('tenant-123');
+    expect(creds.clientId).toBe('client-abc');
+    expect(creds.clientSecret).toBe('secret-xyz');
+  });
+
+  it('parseCredentialsFromHeaders drops a placeholder API key', () => {
+    const creds = parseCredentialsFromHeaders({
+      'x-api-key': API_KEY_PLACEHOLDER,
+      'x-tenant-id': 'tenant-123',
+      'x-client-id': 'client-abc',
+      'x-client-secret': 'secret-xyz',
+    });
+
+    expect(creds.apiKey).toBeUndefined();
+    expect(creds.tenantId).toBe('tenant-123');
+  });
+
+  it('the 401 repro: OAuth path is taken, never a Bearer placeholder', async () => {
+    process.env.CIPP_BASE_URL = 'https://cipp.example';
+    process.env.CIPP_API_KEY = API_KEY_PLACEHOLDER; // blank optional field
+    process.env.CIPP_TENANT_ID = 'tenant-123';
+    process.env.CIPP_CLIENT_ID = 'client-abc';
+    process.env.CIPP_CLIENT_SECRET = 'secret-xyz';
+
+    const config = mergeWithMcpConfig(loadEnvironmentConfig());
+    const svc = new CippService(config, logger);
+
+    // First fetch = Entra token endpoint; second = the CIPP API request.
+    const fetchMock = jest.fn((url: string, _init?: RequestInit) => {
+      if (url.includes('/oauth2/v2.0/token')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({ access_token: 'minted-oauth-token', expires_in: 3600 }),
+        } as unknown as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify([{ customerId: 'contoso' }]),
+      } as unknown as Response);
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await svc.listTenants();
+
+    // A token exchange must have happened — proving the OAuth path engaged
+    // instead of short-circuiting on the truthy placeholder.
+    const tokenCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes('/oauth2/v2.0/token')
+    );
+    expect(tokenCall).toBeDefined();
+
+    const apiCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes('/api/')
+    );
+    expect(apiCall).toBeDefined();
+    const authHeader = (apiCall![1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(authHeader.Authorization).toBe('Bearer minted-oauth-token');
+    expect(authHeader.Authorization).not.toContain('user_config');
+  });
+});


### PR DESCRIPTION
## The bug

MCPB/DXT desktop bundles map env vars to `${user_config.X}` in `manifest.json`. When an **optional** `user_config` field is left blank, Claude Desktop injects the **literal** string `${user_config.X}` into the env var — not empty, not omitted.

CIPP supports two auth modes: a static Bearer **API key** OR **OAuth** client-credentials. A user who configures OAuth and leaves the optional API key blank ends up with:

```
CIPP_API_KEY="${user_config.cipp_api_key}"
```

Because that literal string is **truthy**, the old ingress (`if (creds.apiKey) cippConfig.apiKey = creds.apiKey` in `src/utils/config.ts`) kept it, and `CippService` (`cipp.service.ts`, `if (!apiKey && tenantId && clientId && clientSecret)`) never built the OAuth `TokenProvider`. Every request then went out as:

```
Authorization: Bearer ${user_config.cipp_api_key}
```

→ a guaranteed **401 on every call**, even with valid OAuth credentials configured. This is the exact silent-credential-override twin of **itglue-mcp #73**.

## The fix

Sanitise credentials at ingress in `src/utils/config.ts`:

```ts
const CONFIG_PLACEHOLDER = /^\$\{.*\}$/;
export function cleanCredential(value: string | undefined): string | undefined {
  const trimmed = value?.trim();
  if (!trimmed || CONFIG_PLACEHOLDER.test(trimmed)) return undefined;
  return trimmed;
}
```

A `sanitizeCredentials()` helper applies `cleanCredential` to every field of a `GatewayCredentials` set, so empty, whitespace-only, and `${...}` placeholder values become `undefined` and the auth layer treats them as absent. It is applied to **all three** credential sources, before the truthy `if (creds.apiKey)` assignments:

- `getCredentialsFromGateway()` — gateway env-var promotion (`X_*` / `CIPP_*`)
- `parseCredentialsFromHeaders()` — HTTP headers (`x-api-key`, …)
- the direct `CIPP_*` env reads in `loadEnvironmentConfig()`

With the placeholder stripped, a blank API key falls through to the OAuth path and the `TokenProvider` is built as intended. `manifest.json` is unchanged.

## Tests

New `tests/config.placeholder.test.ts`:

- `cleanCredential` unit tests: `undefined` / `""` / `"  "` / `${user_config.cipp_api_key}` → `undefined`; real values pass through (trimmed).
- `sanitizeCredentials` strips placeholder fields while keeping real ones.
- Ingress tests for all three sources (`loadEnvironmentConfig`, `getCredentialsFromGateway`, `parseCredentialsFromHeaders`): a placeholder `CIPP_API_KEY` resolves to `undefined` while the OAuth fields survive.
- **401 repro**: with `CIPP_API_KEY="${user_config.cipp_api_key}"` alongside valid tenant/client/secret, drive a `CippService.listTenants()` with a mocked `fetch` and assert the OAuth token exchange happens and the API request carries `Authorization: Bearer <minted-token>` — never the Bearer placeholder.

Local checks all green: **lint** (`eslint src`) ✅, **build** (`tsc`) ✅, **test** (`jest`, 29 passed) ✅.

Mirrors **itglue-mcp #73**. Fleet-wide fix.

**DO NOT MERGE** pending review.